### PR TITLE
Fix email validation against the allowed_domains list

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,7 +112,7 @@ class User < ActiveRecord::Base
   extend Forwardable
 
   def email_in_allowed_domain
-    Rails.logger.debug('Check if email address #{email} is valid')
+    Rails.logger.debug("Check if email address #{email} is in the list of allowed domains")
     allowed_email_address = false
     allowed_domains = GalleryConfig.registration.allowed_domains
     aalowed_email_address = true if allowed_domains.size == 0
@@ -120,7 +120,7 @@ class User < ActiveRecord::Base
       allowed_email_address = true if email.end_with? domain
     end
     errors.add(:email, "#{email} is not in the list of allowed domains") unless allowed_email_address
-    Rails.logger.debug('The result of validating #{email} is #{allowed_email_address}')
+    Rails.logger.debug("The result of validating #{email} against the list of allowed domains is #{allowed_email_address}")
   end
 
   # Constructor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,7 +115,7 @@ class User < ActiveRecord::Base
     Rails.logger.debug("Check if email address #{email} is in the list of allowed domains")
     allowed_email_address = false
     allowed_domains = GalleryConfig.registration.allowed_domains
-    aalowed_email_address = true if allowed_domains.size == 0
+    allowed_email_address = true if allowed_domains.size == 0
     allowed_domains&.each do |domain|
       allowed_email_address = true if email.end_with? domain
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,10 +112,15 @@ class User < ActiveRecord::Base
   extend Forwardable
 
   def email_in_allowed_domain
+    Rails.logger.debug('Check if email address #{email} is valid')
+    allowed_email_address = false
     allowed_domains = GalleryConfig.registration.allowed_domains
+    aalowed_email_address = true if allowed_domains.size == 0
     allowed_domains&.each do |domain|
-      errors.add(:email, "#{email} is not in the list of allowed domains") unless email.end_with? domain
+      allowed_email_address = true if email.end_with? domain
     end
+    errors.add(:email, "#{email} is not in the list of allowed domains") unless allowed_email_address
+    Rails.logger.debug('The result of validating #{email} is #{allowed_email_address}')
   end
 
   # Constructor


### PR DESCRIPTION
Email validation against the allowed_domains list didn't work when there was more than one allowed domain.

This is my first pull request ever, so bear with me if I've made mistakes.