### PR TITLE
Accessibility 7: Added NBGallery Preferences, fixed contrast of all elements, and played some catchup

### DIFF
--- a/app/assets/stylesheets/formatters.scss
+++ b/app/assets/stylesheets/formatters.scss
@@ -3,15 +3,15 @@
 .highlight {
     background: #f8f8f8;
     .hll { background-color: #ffc }
-    .c { color: #408080; font-style: italic } /* Comment */
+    .c { color: #3e7c7c; font-style: italic } /* Comment */
     .err { border: 1px solid #f00 } /* Error */
     .k { color: #008000; font-weight: bold } /* Keyword */
     .o { color: #666 } /* Operator */
-    .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-    .cp { color: #bc7a00 } /* Comment.Preproc */
-    .c1 { color: #408080; font-style: italic } /* Comment.Single */
-    .cs { color: #408080; font-style: italic } /* Comment.Special */
-    .gd { color: #A00000 } /* Generic.Deleted */
+    .cm { color: #3e7c7c; font-style: italic } /* Comment.Multiline */
+    .cp { color: #9d6600 } /* Comment.Preproc */
+    .c1 { color: #3e7c7c; font-style: italic } /* Comment.Single */
+    .cs { color: #3e7c7c; font-style: italic } /* Comment.Special */
+    .gd { color: #a00000 } /* Generic.Deleted */
     .ge { font-style: italic } /* Generic.Emph */
     .gr { color: #f00 } /* Generic.Error */
     .gh { color: #000080; font-weight: bold } /* Generic.Heading */
@@ -34,15 +34,15 @@
     .nc { color: #00f; font-weight: bold } /* Name.Class */
     .no { color: #800 } /* Name.Constant */
     .nd { color: #a2f } /* Name.Decorator */
-    .ni { color: #999; font-weight: bold } /* Name.Entity */
-    .ne { color: #d2413a; font-weight: bold } /* Name.Exception */
+    .ni { color: #727272; font-weight: bold } /* Name.Entity */
+    .ne { color: #d03932; font-weight: bold } /* Name.Exception */
     .nf { color: #00f } /* Name.Function */
-    .nl { color: #a0a000 } /* Name.Label */
+    .nl { color: #767600 } /* Name.Label */
     .nn { color: #00f; font-weight: bold } /* Name.Namespace */
     .nt { color: #008000; font-weight: bold } /* Name.Tag */
     .nv { color: #19177c } /* Name.Variable */
     .ow { color: #a2f; font-weight: bold } /* Operator.Word */
-    .w { color: #bbb } /* Text.Whitespace */
+    .w { color: #727272 } /* Text.Whitespace */
     .mb { color: #666 } /* Literal.Number.Bin */
     .mf { color: #666 } /* Literal.Number.Float */
     .mh { color: #666 } /* Literal.Number.Hex */
@@ -52,11 +52,11 @@
     .sc { color: #ba2121 } /* Literal.String.Char */
     .sd { color: #ba2121; font-style: italic } /* Literal.String.Doc */
     .s2 { color: #ba2121 } /* Literal.String.Double */
-    .se { color: #b62; font-weight: bold } /* Literal.String.Escape */
+    .se { color: #ac5e1f; font-weight: bold } /* Literal.String.Escape */
     .sh { color: #ba2121 } /* Literal.String.Heredoc */
-    .si { color: #b68; font-weight: bold } /* Literal.String.Interpol */
+    .si { color: #b25178; font-weight: bold } /* Literal.String.Interpol */
     .sx { color: #008000 } /* Literal.String.Other */
-    .sr { color: #b68 } /* Literal.String.Regex */
+    .sr { color: #b25178 } /* Literal.String.Regex */
     .s1 { color: #ba2121 } /* Literal.String.Single */
     .ss { color: #19177c } /* Literal.String.Symbol */
     .bp { color: #008000 } /* Name.Builtin.Pseudo */

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -859,7 +859,7 @@ body.page-revisions-id .alert.revision-page-alert {
     background-color: #fdd;
 }
 #errorLayout {
-    margin-top: 2em;
+    margin: 2em auto;
     width: 85%;
     img {
         height: 55px;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2524,7 +2524,6 @@ body.page-user_preferences {
     display: inline-block;
 }
 
-
 /* ===== Private Pages (For admins) ===== */
 .admin_hidden #commentLink,
 .admin_hidden #notebookFeedback {
@@ -2661,16 +2660,28 @@ body.dark-theme .navbar-wrapper {
 body.dark-theme {
     #topNavbar .logo-link .logo-nb {
         color: $text-color;
-        filter: invert(100%);
     }
-    h1, h2, h3, h4, h5 {
+    h1, h2, h3, h4, h5,
+    .modal .modal-content,
+    #headerIcons > a > .glyphicon,
+    #headerIcons > a > .caret,
+    &.page-summary #main p,
+    &.page-user_preferences #main p,
+    #expandableSearch a,
+    #headericons .nav-bar-icon,
+    #headericons .nav-bar-icon:before,
+    #headericons .nav-bar-icon:after,
+    #notebookDisplay p,
+    #changeReqView p,
+    #groupLanding p,
+    #notebookJumbo p,
+    .no-notebooks,
+    .emptyNotebooks,
+    p.empty {
         color: $secondary-background;
     }
-    .modal .modal-content {
-        background: $secondary-background;
-    }
     .modal .modal-header {
-        background: $primary-border-color;;
+        background: $primary-border-color;
         border-bottom: 1px solid $primary-border-color;
     }
     .modal button.close {
@@ -2686,15 +2697,13 @@ body.dark-theme {
     .super-container,
     .logo-link,
     .logo-loading,
-    .sub-container .form-group {
+    .sub-container .form-group,
+    .sparkline,
+    #topNavbar .logo-link .logo-nb {
         filter: invert(100%);
     }
-    #headerIcons > a > .glyphicon,
-    #headerIcons > a > .caret,
-    &.page-summary #main p,
-    &.page-user_preferences #main p,
-    #expandableSearch a {
-        color: $secondary-background;
+    .language-icon {
+        filter: contrast(200%)invert(100%);
     }
     #expandableSearch:focus,
     #expandableSearch:hover {
@@ -2703,11 +2712,6 @@ body.dark-theme {
         a:focus {
             color: $secondary-color;
         }
-    }
-    #headericons .nav-bar-icon,
-    #headericons .nav-bar-icon:before,
-    #headericons .nav-bar-icon:after {
-        background-color: $secondary-background;
     }
     #mobileNavContainer:hover,
     #mobileNavContainer:focus {
@@ -2764,14 +2768,6 @@ body.dark-theme {
         background: #eee;
         filter: invert(100%);
     }
-    #notebookDisplay,
-    #changeReqView,
-    #groupLanding,
-    #notebookJumbo {
-        p {
-            color: $secondary-background;
-        }
-    }
     #notebookJumbo {
         .glyphicon:not(.author-rep),
         .action-icon:not(.fa-medkit),
@@ -2790,14 +2786,6 @@ body.dark-theme {
     .glyphicon-star {
         color: #eec905 !important;
     }
-    .no-notebooks,
-    .emptyNotebooks,
-    p.empty {
-        color: $secondary-background;
-    }
-    .sparkline {
-        filter: invert(100%);
-    }
     .page-metadata {
         background: #111;
         border-color: #111;
@@ -2805,9 +2793,6 @@ body.dark-theme {
         strong {
             color: $secondary-background;
         }
-    }
-    .language-icon {
-        filter: contrast(200%)invert(100%);
     }
 }
 
@@ -2824,7 +2809,9 @@ body.larger-text-mode {
     h5 { font-size: 200%; }
     p,
     .alert,
-    select {
+    select,
+    td,
+    input {
         font-size: 120%;
     }
     &.page-user_preferences select {
@@ -2840,9 +2827,7 @@ body.larger-text-mode {
         span.badge.badge-notify {
             font-size: 100%;
         }
-        .owner_footer {
-            font-size: 110%;
-        }
+        .owner_footer,
         #snippetInfo {
             font-size: 110%;
         }
@@ -2884,17 +2869,11 @@ body.larger-text-mode {
         font-size: 88%;
     }
     #navbarSearchBar .searchFieldBox {
-      font-size: 16px;
-      top: .35em;
-    }
-    .btn {
-      font-size: 16px;
+        font-size: 16px;
+        top: .35em;
     }
     .button.search-submit {
         top: .35em;
-    }
-    td, input {
-        font-size: 120%;
     }
     .close {
         font-size: 30px;
@@ -2903,7 +2882,9 @@ body.larger-text-mode {
     &.page-groups .list-group li {
         font-size: 150%;
     }
-    .form-control {
+    .btn,
+    .form-control,
+    .github-fork-ribbon a {
         font-size: 16px;
     }
     &.page-subscriptions #main {
@@ -2918,9 +2899,7 @@ body.larger-text-mode {
     #notebookDisplay,
     #changeReqView,
     #groupLanding {
-        p {
-            font-size: 130%;
-        }
+        p,
         pre.highlight {
             font-size: 130%;
         }
@@ -2930,9 +2909,6 @@ body.larger-text-mode {
         .fa-medkit {
             font-size: 20px;
         }
-    }
-    .github-fork-ribbon a {
-        font-size: 16px;
     }
     #groupLanding p.landing-title {
         font-size: 300%;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -243,8 +243,21 @@ body.page-admin .navbar-wrapper {
     margin: 0;
     .logo-link {
         display: inline-block;
+        font-size: 38px;
         position: relative;
+        text-decoration: none;
         top: 2.5px;
+        .logo-nb {
+            background: $secondary-color;
+            border-radius: .6em;
+            color: #fff;
+            font-weight: bold;
+            letter-spacing: -2px;
+            padding: 1px 2px;
+        }
+        .logo-gallery {
+            color: #000;
+        }
     }
     .navbar-nav a {
         margin-right: 5px;
@@ -265,7 +278,7 @@ body.page-admin .navbar-wrapper {
     .dropdown.navbar-right > a:focus .gear,
     .dropdown.navbar-right > a:hover .caret,
     .dropdown.navbar-right > a:focus .caret{
-        color: $secondary-link-color;
+        color: $secondary-color;
         transition: .3s all;
     }
     .navbar-collapse {
@@ -361,7 +374,7 @@ body.page-admin .navbar-wrapper {
     }
     .search-submit:hover span.glyphicon.glyphicon-search,
     .search-submit:focus span.glyphicon.glyphicon-search {
-        color: $secondary-link-color;
+        color: $secondary-color;
     }
     @media all and (max-width: 649px) {
         display: none;
@@ -369,7 +382,7 @@ body.page-admin .navbar-wrapper {
 }
 button.search-submit:focus span.glyphicon.glyphicon-search,
 button.search-submit:hover span.glyphicon.glyphicon-search {
-    color: $secondary-link-color;
+    color: $secondary-color;
 }
 #notebookFilterDropDownFullThing {
     @media all and (max-width: 799px) {
@@ -499,7 +512,7 @@ span.review-alert {
     &:focus .nav-bar-icon:after,
     &:hover .nav-bar-icon:before,
     &:focus .nav-bar-icon:before, {
-        background-color: $secondary-link-color;
+        background-color: $secondary-color;
     }
     #mobileNavBar {
         color: $lighter-icon-color;
@@ -633,7 +646,7 @@ span.review-alert {
     &:focus,
     a:hover,
     a:focus {
-        color: $secondary-link-color;
+        color: $secondary-color;
         outline: 0;
     }
     @media all and (max-width: 649px) {
@@ -941,7 +954,7 @@ body.page-revisions-id .alert.revision-page-alert {
         background: #f1f1f1;
     }
     a {
-        color: $secondary-color;
+        color: $secondary-link-color;
     }
     p {
         display: inline;
@@ -1163,6 +1176,14 @@ body.page-revisions-id .alert.revision-page-alert {
         outline: 0;
     }
 }
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus {
+    color: $intermediate-icon-color;
+}
 
 /* ===== Notebook Jumbotron ===== */
 #notebookJumbo {
@@ -1170,6 +1191,9 @@ body.page-revisions-id .alert.revision-page-alert {
     border-radius: 6px;
     margin: 1.5em 0 13px;
     padding: 2em 4em 1.2em;
+    .metadata-container > p > a {
+        color: $primary-link-color-darker;
+    }
     @media all and (max-width: 800px) {
         padding: 2em 2em 1.2em;
     }
@@ -1301,7 +1325,7 @@ body.page-revisions-id .alert.revision-page-alert {
         text-decoration: underline;
     }
     a:focus {
-        outline: 1px dotted $secondary-link-color;
+        outline: 1px dotted $secondary-color;
     }
     strong {
         font-weight: normal;
@@ -1349,7 +1373,7 @@ body.page-revisions-id .alert.revision-page-alert {
         font-size: large !important;
         outline: 0;
         &:hover {
-            color: $secondary-link-color;
+            color: $secondary-color;
         }
     }
 }
@@ -1738,7 +1762,7 @@ p.description {
 }
 .carousel-caption a:hover,
 .carousel-caption a:focus {
-    color: $secondary-link-color;
+    color: $secondary-color;
     transition: .3s all;
 }
 #subscriptionToggle:hover i,
@@ -1862,7 +1886,7 @@ body.page-home .tabs {
     }
     .tab a {
         border-bottom: .4em solid $primary-border-color;
-        color: $lighter-icon-color;
+        color: $intermediate-icon-color;
         cursor: pointer;
         display: block;
         font-size: 15.5px;
@@ -1874,15 +1898,15 @@ body.page-home .tabs {
     }
     .tab a:hover,
     .tab a:focus {
-        border-bottom: .4em solid #666;
-        color: #666;
+        border-bottom: .4em solid $intermediate-icon-color;
+        color: $intermediate-icon-color;
         outline: none;
     }
     .tabLink.active,
     .tabLink.active:focus,
     .tabLink.active:hover {
-        border-bottom: .4em solid $secondary-link-color;
-        color: $secondary-link-color;
+        border-bottom: .4em solid $secondary-color;
+        color: $secondary-color;
         text-transform: uppercase;
     }
 }
@@ -2379,6 +2403,9 @@ body.page-change_requests {
 
 /* ===== Change Request Page (/change_requests/{ID}) - Show ===== */
 body.page-change_requests-id {
+    h1 {
+        clear: both;
+    }
     .button-container a {
         display: inline-block;
         margin-bottom: 6px;
@@ -2420,11 +2447,13 @@ i.glyphicon-alert {
 }
 
 /* ===== Change Request Page (/change_requests/all) - All ===== */
-#allChangeRequestsPage td:last-child {
-    font-size: 100%;
-}
-#allChangeRequestsPage tr.success {
-    background: #ceffce;
+body.page-change_requests-all {
+    td:last-child {
+        font-size: 100%;
+    }
+    tr.success {
+        background: #ceffce;
+    }
 }
 
 /* ===== Tags Page (/tags) ===== */
@@ -2476,6 +2505,26 @@ body.page-groups .list-group li {
     margin-bottom: .2em;
 }
 
+/* ===== User Preferences ===== */
+body.page-user_preferences {
+    #currentTimezone,
+    label p {
+        display: inline-block;
+        margin-left: .5em;
+    }
+    h2 {
+        margin-top: 1em;
+    }
+    select {
+        height: 34px;
+        padding: .5em;
+    }
+}
+#savePreferences {
+    display: inline-block;
+}
+
+
 /* ===== Private Pages (For admins) ===== */
 .admin_hidden #commentLink,
 .admin_hidden #notebookFeedback {
@@ -2510,6 +2559,9 @@ body.page-groups .list-group li {
     position: absolute;
     vertical-align: top;
     z-index: 0;
+    a {
+        color: $primary-link-color-darker;
+    }
     ul {
         margin: 0;
         padding: 0;
@@ -2551,7 +2603,7 @@ body.page-groups .list-group li {
 }
 .admin-metric-area {
     display: inline-block;
-    padding-left: 270px;
+    padding-left: 300px;
     vertical-align: top;
     width: 100%;
     h1 {
@@ -2599,4 +2651,307 @@ body.page-groups .list-group li {
 .admin-metrics > hr {
     border-color: $primary-border-color;
     margin: 15px 1%;
+}
+
+/* ===== DARK MODE ===== */
+body.dark-theme,
+body.dark-theme .navbar-wrapper {
+    background: #333;
+}
+body.dark-theme {
+    #topNavbar .logo-link .logo-nb {
+        color: $text-color;
+        filter: invert(100%);
+    }
+    h1, h2, h3, h4, h5 {
+        color: $secondary-background;
+    }
+    .modal .modal-content {
+        background: $secondary-background;
+    }
+    .modal .modal-header {
+        background: $primary-border-color;;
+        border-bottom: 1px solid $primary-border-color;
+    }
+    .modal button.close {
+        color: #333;
+        &:hover,
+        &:focus {
+            color: $error-text-color;
+        }
+    }
+    .modal-title {
+        color: $text-color;
+    }
+    .super-container,
+    .logo-link,
+    .logo-loading,
+    .sub-container .form-group {
+        filter: invert(100%);
+    }
+    #headerIcons > a > .glyphicon,
+    #headerIcons > a > .caret,
+    &.page-summary #main p,
+    &.page-user_preferences #main p,
+    #expandableSearch a {
+        color: $secondary-background;
+    }
+    #expandableSearch:focus,
+    #expandableSearch:hover {
+        a,
+        a:hover,
+        a:focus {
+            color: $secondary-color;
+        }
+    }
+    #headericons .nav-bar-icon,
+    #headericons .nav-bar-icon:before,
+    #headericons .nav-bar-icon:after {
+        background-color: $secondary-background;
+    }
+    #mobileNavContainer:hover,
+    #mobileNavContainer:focus {
+        .nav-bar-icon,
+        .nav-bar-icon:before,
+        .nav-bar-icon:after {
+          background-color: $secondary-link-color;
+        }
+    }
+    table tbody tr:nth-child(odd),
+    table tbody tr:nth-child(even) {
+        background: $intermediate-icon-color;
+    }
+    table.clean-table,
+    table.centered-table,
+    table#searchTable,
+    .modal table {
+        tbody tr:nth-child(odd),
+        tbody tr:nth-child(even) {
+            background: $secondary-background;
+        }
+    }
+    table th {
+        background: #bbb
+    }
+    table.dataTable thead th.sorting {
+        background: #bbb !important;
+    }
+    #nbTable tr:nth-child(even),
+    .dropdown-menu {
+        background: $secondary-background;
+    }
+    .dropdown-menu > li > a:hover,
+    .dropdown-menu > li > a:focus {
+        background: #c3c3c3;
+        color: $text-color;
+    }
+    #nbTable tr:nth-child(even),
+    #notebookJumbo.info {
+        background: #111;
+    }
+    #nbTable tr:nth-child(odd),
+    #nbTable tr:nth-child(even) {
+        .tags span.glyphicon,
+        #nb-description,
+        a.title,
+        .owner_footer,
+        #snippetInfo,
+        .badge  {
+            color: $secondary-background;
+        }
+    }
+    pre.highlight {
+        background: #eee;
+        filter: invert(100%);
+    }
+    #notebookDisplay,
+    #changeReqView,
+    #groupLanding,
+    #notebookJumbo {
+        p {
+            color: $secondary-background;
+        }
+    }
+    #notebookJumbo {
+        .glyphicon:not(.author-rep),
+        .action-icon:not(.fa-medkit),
+        .badge,
+        .caret {
+            color: $secondary-background;
+        }
+        #notebookGearActions .glyphicon {
+            color: $intermediate-icon-color;
+        }
+        .notebook-actions > a:hover span,
+        .notebook-actions > a:focus span {
+            color: $secondary-color;
+        }
+    }
+    .glyphicon-star {
+        color: #eec905 !important;
+    }
+    .no-notebooks,
+    .emptyNotebooks,
+    p.empty {
+        color: $secondary-background;
+    }
+    .sparkline {
+        filter: invert(100%);
+    }
+    .page-metadata {
+        background: #111;
+        border-color: #111;
+        p,
+        strong {
+            color: $secondary-background;
+        }
+    }
+    .language-icon {
+        filter: contrast(200%)invert(100%);
+    }
+}
+
+/* ===== LARGER TEXT MODE ===== */
+body.larger-text-mode {
+    .carousel-caption h1,
+    &.page-notebooks .carousel-caption h1.long-title {
+        font-size: 5vw;
+    }
+    h1 { font-size: 300%; }
+    h2 { font-size: 280%; }
+    h3 { font-size: 240%; }
+    h4 { font-size: 225%; }
+    h5 { font-size: 200%; }
+    p,
+    .alert,
+    select {
+        font-size: 120%;
+    }
+    &.page-user_preferences select {
+        height: 40px;
+    }
+    #nbTable {
+        .title-wrapper .title {
+            font-size :180%;
+        }
+        p {
+            font-size: 150%;
+        }
+        span.badge.badge-notify {
+            font-size: 100%;
+        }
+        .owner_footer {
+            font-size: 110%;
+        }
+        #snippetInfo {
+            font-size: 110%;
+        }
+    }
+    .tagRow a span {
+        font-size: 16px !important;
+        font-weight: normal;
+    }
+    #notebookJumbo {
+        p {
+            font-size :130%;
+        }
+        .glyphicon {
+            font-size: 24px;
+        }
+        #tagsDisplay .badge,
+        .tag-edit-mode .badge {
+            font-size: 120%;
+        }
+        #recommendationToggle {
+            font-size: 19px;
+            top: .9em;
+        }
+    }
+    .dropdown-menu {
+        font-size: 18px;
+        .badge {
+            font-size: 14px;
+        }
+    }
+    .nav-bar-icon-container {
+        top: -.18em;
+    }
+    .gear,
+    #expandableSearch {
+        font-size: 22px;
+    }
+    #headerIcons span.review-alert {
+        font-size: 88%;
+    }
+    #navbarSearchBar .searchFieldBox {
+      font-size: 16px;
+      top: .35em;
+    }
+    .btn {
+      font-size: 16px;
+    }
+    .button.search-submit {
+        top: .35em;
+    }
+    td, input {
+        font-size: 120%;
+    }
+    .close {
+        font-size: 30px;
+    }
+    textarea,
+    &.page-groups .list-group li {
+        font-size: 150%;
+    }
+    .form-control {
+        font-size: 16px;
+    }
+    &.page-subscriptions #main {
+        p {
+            font-size: 130%;
+        }
+        i.fa-fa-eye {
+            font-size: 120%;
+        }
+    }
+    &.page-code_cells-id #main,
+    #notebookDisplay,
+    #changeReqView,
+    #groupLanding {
+        p {
+            font-size: 130%;
+        }
+        pre.highlight {
+            font-size: 130%;
+        }
+        .cell-health {
+            right: 30px;
+        }
+        .fa-medkit {
+            font-size: 20px;
+        }
+    }
+    .github-fork-ribbon a {
+        font-size: 16px;
+    }
+    #groupLanding p.landing-title {
+        font-size: 300%;
+    }
+    .lead {
+        font-size: 26px;
+    }
+    &.page-admin {
+        .admin-links-container a {
+            font-size: 18px;
+        }
+        li.sub-heading {
+            margin-top: .5em;
+        }
+        .scorecard h2 {
+            font-size: 200%;
+        }
+        .scorecard p {
+            font-size: 180%;
+        }
+    }
 }

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -21,6 +21,7 @@ $alert-font-family: $secondary-font-family;
 $text-color: #000;
 $header-color: #333;
 $darker-icon-color: #333;
+$intermediate-icon-color: #666;
 $lighter-icon-color: #777;
 $error-text-color: #f00;
 $text-weight: 400;
@@ -76,6 +77,7 @@ $primary-link-color-visited: $primary-link-color;
 $primary-link-color-hover: $primary-color-darker;
 $primary-link-color-focus: $primary-link-color-hover;
 $primary-link-color-active: $primary-link-color-hover;
+$primary-link-color-darker: darken($primary-link-color, 3%);
 %primary-link-styles {
     color: $primary-link-color;
     &:visited {
@@ -93,7 +95,7 @@ $primary-link-color-active: $primary-link-color-hover;
     }
 }
 
-$secondary-link-color: $secondary-color;
+$secondary-link-color: #b35016; //need for 4.5:1 contrast ratio
 $secondary-link-color-visited: $secondary-link-color;
 $secondary-link-color-hover: $secondary-color-darker;
 $secondary-link-color-focus: $secondary-link-color-hover;

--- a/app/controllers/user_preferences_controller.rb
+++ b/app/controllers/user_preferences_controller.rb
@@ -1,0 +1,34 @@
+class UserPreferencesController < ApplicationController
+  def index
+    @user_preference = UserPreference.find_or_create_by(user_id: @user.id)
+  end
+
+  # POST /user_preferences#create
+  def create
+    @user_preference = UserPreference.find_or_create_by(user_id: @user.id)
+    if params[:theme] == "default"
+      @user_preference.theme = nil
+    else
+      @user_preference.theme = params[:theme]
+    end
+    @user_preference.timezone = params[:timezone]
+    if params[:high_contrast] == "true"
+      @user_preference.high_contrast = TRUE
+    else
+      @user_preference.high_contrast = FALSE
+    end
+    if params[:larger_text] == "true"
+      @user_preference.larger_text = TRUE
+    else
+      @user_preference.larger_text = FALSE
+    end
+    if params[:ultimate_accessibility_mode] == "true"
+      @user_preference.ultimate_accessibility_mode = TRUE
+    else
+      @user_preference.ultimate_accessibility_mode = FALSE
+    end
+    @user_preference.save
+    flash[:success] = "Successfully updated user preferences."
+    redirect_to(:back)
+  end
+end

--- a/app/controllers/user_preferences_controller.rb
+++ b/app/controllers/user_preferences_controller.rb
@@ -28,7 +28,7 @@ class UserPreferencesController < ApplicationController
       @user_preference.ultimate_accessibility_mode = FALSE
     end
     @user_preference.save
-    flash[:success] = "Successfully updated user preferences."
+    flash[:success] = "Successfully updated #{GalleryConfig.site.name} preferences."
     redirect_to(:back)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,10 @@
 module ApplicationHelper
   def color_for(string)
     @colors ||= [
-      '#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf'
+      #'#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf' //better but not 4.5:1 contrast ratio (accessibility)
+      '#1f77b4', '#be5900', '#258825', '#d62728', '#8f60ba', '#8c564b', '#d32ba0', '#757575', '#797a16', '#10838e'
     ]
+
     @colors[string.sum % @colors.size]
   end
 

--- a/app/helpers/user_preference_helper.rb
+++ b/app/helpers/user_preference_helper.rb
@@ -1,0 +1,2 @@
+module UserPreferenceHelper
+end

--- a/app/helpers/user_preference_helper.rb
+++ b/app/helpers/user_preference_helper.rb
@@ -1,2 +1,0 @@
-module UserPreferenceHelper
-end

--- a/app/models/user_preference.rb
+++ b/app/models/user_preference.rb
@@ -1,0 +1,6 @@
+class UserPreference < ActiveRecord::Base
+  belongs_to :user
+  
+  include ExtendableModel
+
+end

--- a/app/views/change_requests/all.slim
+++ b/app/views/change_requests/all.slim
@@ -1,4 +1,4 @@
-div.content-container.center id="allChangeRequestsPage"
+div.content-container.center
   -unless @change_requests.empty?
     h1 All Change Requests
     table.clean-table.review-table

--- a/app/views/change_requests/show.slim
+++ b/app/views/change_requests/show.slim
@@ -122,7 +122,7 @@ javascript:
   });
 
 ==csrf_meta_tag
-div.content-container id="changeRequestPage"
+div.content-container
   div.return
     a.tooltips href="#{change_requests_path}" title="Go to Change Requests page" aria-label="Go to change requests page"
       i.fa.fa-share aria-hidden="true"

--- a/app/views/languages/index.slim
+++ b/app/views/languages/index.slim
@@ -6,5 +6,11 @@ div.content-container
       li.list-group-item
         a.tooltips href="#{language_link(lang, version)}" title="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}" aria-label="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}"
           ==image_tag(language_thumbnail(lang, version))
-          ="#{lang.capitalize}#{version ? ' ' + version : ''}"
-        span.badge.searchResultGroup.tooltips title="#{count} Notebooks" aria-label="#{count} Notebooks" =count
+          =="#{lang.capitalize}#{version ? ' ' + version : ''}"
+        span.sr-only #{" "}
+        span.badge.searchResultGroup.tooltips title="#{count} Notebooks" aria-label="#{count} Notebooks"
+          span.hidden aria-hidden="true" #{"("}
+          ==count
+          span.sr-only
+            |  Notebooks
+          span.hidden aria-hidden="true" #{")"}

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -88,7 +88,7 @@ html lang="en"
       -body_classes += "page-#{url_check[-1]} "
   -if url_check[2] != nil
     -body_classes += "directory-#{url_check[1]} "
-  -body_classes += "path#{url_check.join("-")} "
+  -body_classes += "path#{url_check.join('-')} "
 
   body class="beta_layout #{body_classes}"
     div.content-container

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -60,11 +60,12 @@ html lang="en"
   -body_classes += "path#{url_check.join("-")} "
 
   body class="beta_layout #{body_classes}"
+    div.content-container
+      a.skip data-turbolinks="false" href="#main" tabindex="1" Skip to main content
     div id="wrapper"
       div id="contents"
         div.navbar-wrapper
           div.content-container
-            a.skip data-turbolinks="false" href="#main" tabindex="1" Skip to main content
             div.navbar.navbar-default id="topNavbar"
               div.navbar-inner
                 a.logo-link href="/" tabindex="2"
@@ -246,8 +247,8 @@ html lang="en"
                         -else
                           span.glyphicon.glyphicon-user.gear.modal-activate data-toggle="modal" data-target="#login-modal"
                       -if @user.member?
-                        div id="gearDropdownMenu" style=(@user.shares.count > 0 ? "min-width: 265px; display: none;" : "display: none")
-                          ul.dropdown-menu.cog
+                        div id="gearDropdownMenu" style="display: none"
+                          ul.dropdown-menu.cog style=(@user.shares.count > 0 ? "min-width: 265px" : "")
                             li.dropdown-header.filter-item My Settings
                             /*li
                               a.beta style="cursor:pointer" tabindex="0"

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -37,11 +37,42 @@ html lang="en"
     ==favicon_link_tag "nb.ico"
     ==javascript_include_tag "application", "data-turbolinks-track" => true
     ==stylesheet_link_tag "application", media: "all"
+    -user_pref = UserPreference.find_by(user_id: @user.id)
+    -if user_pref.theme == "dark"
+      -dark = TRUE
+    -elsif user_pref.theme == "grayscale"
+      css:
+        body {
+          filter: grayscale(100%);
+        }
+    -elsif user_pref.theme == "ultra-dark"
+      css:
+        body {
+          filter: saturate(150%)invert(100%)
+        }
+        #topNavbar .logo-link .logo-nb {
+            color: #000;
+            filter: invert(100%);
+        }
+    -elsif user_pref.theme == "juicy"
+      css:
+        body {
+          filter: saturate(180%)
+        }
+    -if user_pref.high_contrast == TRUE
+      css:
+        html {
+          filter: contrast(120%)
+        }
+    -if user_pref.larger_text == TRUE
+      -larger_text = TRUE
 
   ==render partial: "custom_banner"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes += "dark-theme " if dark == TRUE
+  -body_classes += "larger-text-mode " if larger_text == TRUE
   -if request.path == "/"
     -body_classes += "page-home "
   -if url_check[2] != nil
@@ -69,8 +100,8 @@ html lang="en"
             div.navbar.navbar-default id="topNavbar"
               div.navbar-inner
                 a.logo-link href="/" tabindex="2"
-                  span.logo-nb nb
-                  span.logo-gallery gallery
+                    span.logo-nb nb
+                    span.logo-gallery gallery
                 div.collapse.navbar-collapse
                   div.header-buttons
                     a href="/video" id="launchTour" tabindex="-1"
@@ -365,7 +396,7 @@ html lang="en"
           ==render partial: "modals/upload.slim"
           ==render partial: "modals/environment_loading"
           ==render partial: "modals/new_group.slim"
-          -if url_check[1] == "groups" && url_check[2] != nil && url_check[2][0..3] =~ /\d/
+          -if url_check[1] == "groups" && url_check[2] != nil && url_check[2][0..3] =~ /\d/ && @group != nil
             ==render partial: "modals/manage_group"
             ==render partial: "modals/view_group"
           -elsif (url_check[1] == "notebooks" || url_check[1] == "notebook" || url_check[1] == "nb") && @notebook != nil

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -41,7 +41,7 @@ html lang="en"
   ==render partial: "custom_banner"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
-  -body_classes = "browser-#{browser.name.downcase} browser-full-#{browser.name.downcase}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
   -if request.path == "/"
     -body_classes += "page-home "
   -if url_check[2] != nil
@@ -69,7 +69,8 @@ html lang="en"
             div.navbar.navbar-default id="topNavbar"
               div.navbar-inner
                 a.logo-link href="/" tabindex="2"
-                  ==image_tag("nbgallery_logo.png", id: "logo")
+                  span.logo-nb nb
+                  span.logo-gallery gallery
                 div.collapse.navbar-collapse
                   div.header-buttons
                     a href="/video" id="launchTour" tabindex="-1"
@@ -262,6 +263,9 @@ html lang="en"
                             li
                               a href="#{preferences_path}"
                                 span.tab Jupyter Preferences
+                            li
+                              a href="#{user_preferences_path}"
+                                span.tab #{GalleryConfig.site.name} Preferences
                             li.divider
                             li.dropdown-header.filter-item My Resources
                             -unless @user.notebooks.count.zero?

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -38,34 +38,30 @@ html lang="en"
     ==javascript_include_tag "application", "data-turbolinks-track" => true
     ==stylesheet_link_tag "application", media: "all"
     -user_pref = UserPreference.find_by(user_id: @user.id)
-    -if user_pref.theme == "dark"
-      -dark = TRUE
-    -elsif user_pref.theme == "grayscale"
-      css:
-        body {
-          filter: grayscale(100%);
-        }
-    -elsif user_pref.theme == "ultra-dark"
-      css:
-        body {
-          filter: saturate(150%)invert(100%)
-        }
-        #topNavbar .logo-link .logo-nb {
-            color: #000;
-            filter: invert(100%);
-        }
-    -elsif user_pref.theme == "juicy"
-      css:
-        body {
-          filter: saturate(180%)
-        }
-    -if user_pref.high_contrast == TRUE
-      css:
-        html {
-          filter: contrast(120%)
-        }
-    -if user_pref.larger_text == TRUE
-      -larger_text = TRUE
+    -if user_pref != nil
+      -if user_pref.theme == "dark"
+        -dark = TRUE
+      -elsif user_pref.theme == "grayscale"
+        css:
+          body {
+            filter: grayscale(100%);
+          }
+      -elsif user_pref.theme == "ultra-dark"
+        css:
+          body {
+            filter: saturate(150%)invert(100%)
+          }
+          #topNavbar .logo-link .logo-nb {
+              color: #000;
+              filter: invert(100%);
+          }
+      -if user_pref.high_contrast == TRUE
+        css:
+          html {
+            filter: contrast(120%)
+          }
+      -if user_pref.larger_text == TRUE
+        -larger_text = TRUE
 
   ==render partial: "custom_banner"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -88,7 +88,7 @@ html lang="en"
       -body_classes += "page-#{url_check[-1]} "
   -if url_check[2] != nil
     -body_classes += "directory-#{url_check[1]} "
-  -body_classes += "path#{url_check.join("-")} "
+  -body_classes += "path#{url_check.join('-')} "
 
   body class="#{body_classes}"
     div.content-container

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -60,11 +60,12 @@ html lang="en"
   -body_classes += "path#{url_check.join("-")} "
 
   body class="#{body_classes}"
+    div.content-container
+      a.skip data-turbolinks="false" href="#main" tabindex="1" Skip to main content
     div id="wrapper"
       div id="contents"
         div.navbar-wrapper
           div.content-container
-            a.skip data-turbolinks="false" href="#main" tabindex="1" Skip to main content
             div.navbar.navbar-default id="topNavbar"
               div.navbar-inner
                 a.logo-link href="/" tabindex="2"
@@ -246,8 +247,8 @@ html lang="en"
                         -else
                           span.glyphicon.glyphicon-user.gear.modal-activate data-toggle="modal" data-target="#login-modal"
                       -if @user.member?
-                        div id="gearDropdownMenu" style=(@user.shares.count > 0 ? "min-width: 265px; display: none;" : "display: none")
-                          ul.dropdown-menu.cog
+                        div id="gearDropdownMenu" style="display: none"
+                          ul.dropdown-menu.cog style=(@user.shares.count > 0 ? "min-width: 265px" : "")
                             li.dropdown-header.filter-item My Settings
                             /*li
                               a.beta style="cursor:pointer" tabindex="0"

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -38,34 +38,30 @@ html lang="en"
     ==javascript_include_tag "application", "data-turbolinks-track" => true
     ==stylesheet_link_tag "application", media: "all"
     -user_pref = UserPreference.find_by(user_id: @user.id)
-    -if user_pref.theme == "dark"
-      -dark = TRUE
-    -elsif user_pref.theme == "grayscale"
-      css:
-        body {
-          filter: grayscale(100%);
-        }
-    -elsif user_pref.theme == "ultra-dark"
-      css:
-        body {
-          filter: saturate(150%)invert(100%)
-        }
-        #topNavbar .logo-link .logo-nb {
-            color: #000;
-            filter: invert(100%);
-        }
-    -elsif user_pref.theme == "juicy"
-      css:
-        body {
-          filter: saturate(180%)
-        }
-    -if user_pref.high_contrast == TRUE
-      css:
-        html {
-          filter: contrast(120%)
-        }
-    -if user_pref.larger_text == TRUE
-      -larger_text = TRUE
+    -if user_pref != nil
+      -if user_pref.theme == "dark"
+        -dark = TRUE
+      -elsif user_pref.theme == "grayscale"
+        css:
+          body {
+            filter: grayscale(100%);
+          }
+      -elsif user_pref.theme == "ultra-dark"
+        css:
+          body {
+            filter: saturate(150%)invert(100%)
+          }
+          #topNavbar .logo-link .logo-nb {
+              color: #000;
+              filter: invert(100%);
+          }
+      -if user_pref.high_contrast == TRUE
+        css:
+          html {
+            filter: contrast(120%)
+          }
+      -if user_pref.larger_text == TRUE
+        -larger_text = TRUE
 
   ==render partial: "custom_banner"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -37,11 +37,42 @@ html lang="en"
     ==favicon_link_tag "nb.ico"
     ==javascript_include_tag "application", "data-turbolinks-track" => true
     ==stylesheet_link_tag "application", media: "all"
+    -user_pref = UserPreference.find_by(user_id: @user.id)
+    -if user_pref.theme == "dark"
+      -dark = TRUE
+    -elsif user_pref.theme == "grayscale"
+      css:
+        body {
+          filter: grayscale(100%);
+        }
+    -elsif user_pref.theme == "ultra-dark"
+      css:
+        body {
+          filter: saturate(150%)invert(100%)
+        }
+        #topNavbar .logo-link .logo-nb {
+            color: #000;
+            filter: invert(100%);
+        }
+    -elsif user_pref.theme == "juicy"
+      css:
+        body {
+          filter: saturate(180%)
+        }
+    -if user_pref.high_contrast == TRUE
+      css:
+        html {
+          filter: contrast(120%)
+        }
+    -if user_pref.larger_text == TRUE
+      -larger_text = TRUE
 
   ==render partial: "custom_banner"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
-  -body_classes = "browser-#{browser.name.downcase} browser-full-#{browser.name.downcase}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes += "dark-theme " if dark == TRUE
+  -body_classes += "larger-text-mode " if larger_text == TRUE
   -if request.path == "/"
     -body_classes += "page-home "
   -if url_check[2] != nil
@@ -69,7 +100,8 @@ html lang="en"
             div.navbar.navbar-default id="topNavbar"
               div.navbar-inner
                 a.logo-link href="/" tabindex="2"
-                  ==image_tag("nbgallery_logo.png", id: "logo")
+                    span.logo-nb nb
+                    span.logo-gallery gallery
                 div.collapse.navbar-collapse
                   div.header-buttons
                     a href="/video" id="launchTour" tabindex="-1"
@@ -262,6 +294,9 @@ html lang="en"
                             li
                               a href="#{preferences_path}"
                                 span.tab Jupyter Preferences
+                            li
+                              a href="#{user_preferences_path}"
+                                span.tab #{GalleryConfig.site.name} Preferences
                             li.divider
                             li.dropdown-header.filter-item My Resources
                             -unless @user.notebooks.count.zero?

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -193,7 +193,7 @@ div.content-container
         ==@notebook.description
       -if @user.can_edit?(@notebook)
         a id="editDescription" href="#"
-          span.glyphicon.glyphicon-pencil.tooltips title="Click anywhere in the description to edit"
+          span.glyphicon.glyphicon-pencil.tooltips title="Edit description"
             span.sr-only Edit description
     form id="descriptionEditForm" enctype="multipart/form-data" role="form" style="display: none"
       div.input-group data-toggle="tooltip" title="Edit description here"

--- a/app/views/preferences/index.slim
+++ b/app/views/preferences/index.slim
@@ -14,7 +14,7 @@ div.content-container
         th Easy Buttons
     tbody
       tr
-        td =@preference.auto_close_brackets
-        td =@preference.smart_indent
-        td =@preference.tab_size
-        td =@preference.easy_buttons
+        td ==@preference.auto_close_brackets
+        td ==@preference.smart_indent
+        td ==@preference.tab_size
+        td ==@preference.easy_buttons

--- a/app/views/preferences/index.slim
+++ b/app/views/preferences/index.slim
@@ -2,8 +2,8 @@ div.content-container
   h1.center Jupyter Client Preferences
   div.alert.alert-info
     i.fa.fa-info-circle aria-hidden="true"
-    p.center Preferences can be saved from the Jupyter instance associated with this Gallery.<br>
-    p.center These can be changed within the <b> Preferences </b> menu in the Jupyter client
+    p.center Preferences can be saved from the Jupyter instance associated with this Gallery.
+    p.center These can be changed within the Preferences menu in the Jupyter client.
   table.centered-table
     caption.sr-only Preferences
     thead

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -35,8 +35,6 @@ div.content-container id="revisionsPage"
                 div.review-icon-container
                   -if total_reviews_left > 0 #for efficiency
                     -0.upto(@notebook.reviews.length - 1) do |review_index|
-                      -if review_index != 0
-                        span.sr-only #{" "}
                       -@review = @notebook.reviews[review_index]
                       -if @review.revision.commit_id == rev.commit_id
                         -total_reviews_left -= 1

--- a/app/views/subscriptions/index.slim
+++ b/app/views/subscriptions/index.slim
@@ -23,7 +23,7 @@ div.content-container id="subscriptionPage"
                     a.subscription-link.tooltips href="#{url_for(Notebook.find(sub.sub_id))}"
                       ==Notebook.find(sub.sub_id).title
                   -else
-                    p style="margin: 0;" PRIVATE_NOTEBOOK
+                    span style="margin: 0;" PRIVATE_NOTEBOOK
                 -elsif sub.sub_type == "group"
                   a.subscription-link.tooltips href="#{url_for(Group.find(sub.sub_id))}"
                     ==Group.find(sub.sub_id).name

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -1,0 +1,153 @@
+javascript:
+  $(document).ready(function(){
+    $('#savePreferences').click(function(){
+      var url = '/user_preferences';
+      var data = $('#userPreferencesForm').serialize();
+      console.log(data)
+      $.ajax({
+        url: url,
+        data: data,
+        type: 'POST',
+        success: function(){
+          window.location.replace('/user_preferences');
+        },
+        failure: function(response){
+          bootbox.alert(response.statusText);
+          console.log(response);
+        }
+      });
+      return false;
+    });
+  });
+
+div.content-container
+  h1.center #{GalleryConfig.site.name} Preferences
+  ==form_tag '/user_preferences', id: 'userPreferencesForm', enctype: 'multipart/form-data', role: 'form' do
+    h2 Themes
+    div.alert.alert-info
+      i.fa.fa-info-circle aria-hidden="true"
+      | Note, will only work on modern browsers.
+    select name="theme" id="theme"
+      -if @user_preference.theme == nil
+        option value="default" Default
+        option value="dark" Dark Theme
+        option value="grayscale" Grayscale Theme
+        option value="ultra-dark" Ultra Dark Theme
+        option value="juicy" Juicy Theme
+      -else
+        option value="default" Default
+        -if @user_preference.theme == "dark"
+          option value="dark" selected="selected" Dark Theme
+          option value="grayscale" Grayscale Theme
+          option value="ultra-dark" Ultra Dark Theme
+          option value="juicy" Juicy Theme
+        -elsif @user_preference.theme == "grayscale"
+          option value="dark" Dark Theme
+          option value="grayscale" selected="selected" Grayscale Theme
+          option value="ultra-dark" Ultra Dark Theme
+          option value="juicy" Juicy Theme
+        -elsif @user_preference.theme == "ultra-dark"
+          option value="dark" Dark Theme
+          option value="grayscale" Grayscale Theme
+          option value="ultra-dark" selected="selected" Ultra Dark Theme
+          option value="juicy" Juicy Theme
+        -else
+          option value="dark" Dark Theme
+          option value="grayscale" Grayscale Theme
+          option value="ultra-dark" Ultra Dark Theme
+          option value="juicy" selected="selected" Juicy Theme
+
+    h2 Additions
+    div.alert.alert-info
+      i.fa.fa-info-circle aria-hidden="true"
+      | Can be used in conjunction with any of the above themes as well as with each other.
+    div
+      label
+        -if @user_preference.high_contrast
+          input id="high_contrast" name="high_contrast" type="checkbox" value="true" checked="checked"
+        -else
+          input id="high_contrast" name="high_contrast" type="checkbox" value="true"
+        p Enable higher contrast
+    div
+      label
+        -if @user_preference.larger_text
+          input id="larger_text" name="larger_text" type="checkbox" value="true" checked="checked"
+        -else
+          input id="larger_text" name="larger_text" type="checkbox" value="true"
+        p Enable larger font
+
+    /*div
+      label
+        -if @user_preference.ultimate_accessibility_mode
+          input id="ultimate_accessibility_mode" name="ultimate_accessibility_mode" type="checkbox" value="true" checked="checked"
+        -else
+          input id="ultimate_accessibility_mode" name="ultimate_accessibility_mode" type="checkbox" value="true"
+        p
+          ' Enable Ultimate Accessibility Mode
+          strong #{"[BETA]"}*/
+
+    /*h2 Timezone*/
+    /*p Will adjust all times on the site as you see them into what the respective time is for your timezone.*/
+    /*select name="timezone" id="timezone"
+      option value="-1200" (GMT -12:00) Eniwetok, Kwajalein
+      option value="-1100" (GMT -11:00) Midway Island, Samoa
+      option value="-1000" (GMT -10:00) Hawaii
+      option value="-950" (GMT -9:30) Taiohae
+      option value="-900" (GMT -9:00) Alaska
+      option value="-800" (GMT -8:00) Pacific Time (US &amp; Canada)
+      option value="-700" (GMT -7:00) Mountain Time (US &amp; Canada)
+      option value="-600" (GMT -6:00) Central Time (US &amp; Canada), Mexico City
+      option value="-500" (GMT -5:00) Eastern Time (US &amp; Canada), Bogota, Lima
+      option value="-450" (GMT -4:30) Caracas
+      option value="-400" (GMT -4:00) Atlantic Time (Canada), Caracas, La Paz
+      option value="-350" (GMT -3:30) Newfoundland
+      option value="-300" (GMT -3:00) Brazil, Buenos Aires, Georgetown
+      option value="-200" (GMT -2:00) Mid-Atlantic
+      option value="-100" (GMT -1:00) Azores, Cape Verde Islands
+      option value="0" selected="selected" (GMT) Western Europe Time, London, Lisbon, Casablanca
+      option value="100" (GMT +1:00) Brussels, Copenhagen, Madrid, Paris
+      option value="200" (GMT +2:00) Kaliningrad, South Africa
+      option value="300" (GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg
+      option value="350" (GMT +3:30) Tehran
+      option value="400" (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
+      option value="450" (GMT +4:30) Kabul
+      option value="500" (GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent
+      option value="550" (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
+      option value="575" (GMT +5:45) Kathmandu, Pokhara
+      option value="600" (GMT +6:00) Almaty, Dhaka, Colombo
+      option value="650" (GMT +6:30) Yangon, Mandalay
+      option value="700" (GMT +7:00) Bangkok, Hanoi, Jakarta
+      option value="800" (GMT +8:00) Beijing, Perth, Singapore, Hong Kong
+      option value="875" (GMT +8:45) Eucla
+      option value="900" (GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk
+      option value="950" (GMT +9:30) Adelaide, Darwin
+      option value="1000" (GMT +10:00) Eastern Australia, Guam, Vladivostok
+      option value="1050" (GMT +10:30) Lord Howe Island
+      option value="1100" (GMT +11:00) Magadan, Solomon Islands, New Caledonia
+      option value="1150" (GMT +11:30) Norfolk Island
+      option value="1200" (GMT +12:00) Auckland, Wellington, Fiji, Kamchatka
+      option value="1275" (GMT +12:45) Chatham Islands
+      option value="1300" (GMT +13:00) Apia, Nukualofa
+      option value="1400" (GMT +14:00) Line Islands, Tokelau*/
+    /*span
+      strong id="currentTimezone"
+        | Currently
+        span aria-hidden="true" #{":"}
+      -timezone = @user_preference.timezone
+      -if timezone > 0
+        -timezone = "+" + timezone.to_s.insert(-3,":")
+      -elsif timezone == 0
+        -timezone = "0:00"
+      -else
+        -timezone = timezone.to_s.insert(-3,":")
+      -if timezone[-2..-1] == "50"
+        -timezone[-2..-1] = "30"
+      -elsif timezone[-2..-1] == "75"
+        -timezone[-2..-1] = "45"
+      span
+        |  GMT #{timezone}*/
+
+    hr.divider.show style="display: none"
+    div
+      a id="savePreferences"
+        button.btn.btn-success Save Preferences

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -33,29 +33,24 @@ div.content-container
         option value="dark" Dark Theme
         option value="grayscale" Grayscale Theme
         option value="ultra-dark" Ultra Dark Theme
-        option value="juicy" Juicy Theme
       -else
         option value="default" Default
         -if @user_preference.theme == "dark"
           option value="dark" selected="selected" Dark Theme
           option value="grayscale" Grayscale Theme
           option value="ultra-dark" Ultra Dark Theme
-          option value="juicy" Juicy Theme
         -elsif @user_preference.theme == "grayscale"
           option value="dark" Dark Theme
           option value="grayscale" selected="selected" Grayscale Theme
           option value="ultra-dark" Ultra Dark Theme
-          option value="juicy" Juicy Theme
         -elsif @user_preference.theme == "ultra-dark"
           option value="dark" Dark Theme
           option value="grayscale" Grayscale Theme
           option value="ultra-dark" selected="selected" Ultra Dark Theme
-          option value="juicy" Juicy Theme
         -else
           option value="dark" Dark Theme
           option value="grayscale" Grayscale Theme
           option value="ultra-dark" Ultra Dark Theme
-          option value="juicy" selected="selected" Juicy Theme
 
     h2 Additions
     div.alert.alert-info

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -15,10 +15,10 @@ div.content-container.mobile-expanding
             -if has_sub > 0
               a.nounderline href="#{subscriptions_path}/#{sub.pluck("id").first}" ref="nofollow" data-method="delete" id="subscriptionToggle"
                 i.fa.fa-rss.tooltips style="color:#eec905;" title="Unsubscribe from this user"
-                span.sr-only Unsubscribe from this Notebook
+                span.sr-only Unsubscribe from this user
             -else
               a.nounderline href="#{new_subscription_path}?subid=#{@viewed_user.id}&type=user" ref="nofollow" data-method="patch" id="subscriptionToggle"
                 i.fa.fa-rss.tooltips title="Subscribe to this user"
-                span.sr-only Subscribe to this Notebook
+                span.sr-only Subscribe to this user
             span.hidden aria-hidden="true" #{"]"}
 ==render partial: 'notebooks'

--- a/app/views/warnings/show.slim
+++ b/app/views/warnings/show.slim
@@ -11,7 +11,7 @@ javascript:
         success: function(){
           window.location.replace('/admin/warning');
         },
-        failure: function(reseponse){
+        failure: function(response){
           bootbox.alert(response.statusText);
           console.log(response);
         }
@@ -31,7 +31,7 @@ javascript:
         success: function(){
           window.location.replace('/admin/warning');
         },
-        failure: function(reseponse){
+        failure: function(response){
           bootbox.alert(response.statusText);
           console.log(response);
         }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do # rubocop: disable Metrics/BlockLength
   resources :subscriptions do
   end
 
+  # User Preferences page
+  resources :user_preferences do
+  end
+
   # Notebook keywords
   resources :keywords, only: [:index] do
     collection do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,15 +115,15 @@ run_in_jupyter:
 
 # Terms of Service Agreement
 tos:
-    message: |
-        I acknowledge that I have all intellectual property rights and approvals (if applicable)
-        <br>
-        for the content contained within this notebook.
+  message: |
+    I acknowledge that I have all intellectual property rights and approvals (if applicable)
+    <br>
+    for the content contained within this notebook.
 
 # URL associated with the feedback page for this instance of the Gallery (i.e. Github issues page, etc)
 feedback:
-    url:
-    beta_poll: https://github.com/nbgallery/nbgallery/issues
+  url:
+  beta_poll: https://github.com/nbgallery/nbgallery/issues
 
 # Video information
 video:

--- a/db/migrate/20191202192605_create_user_preferences.rb
+++ b/db/migrate/20191202192605_create_user_preferences.rb
@@ -1,0 +1,14 @@
+class CreateUserPreferences < ActiveRecord::Migration
+  def change
+    create_table :user_preferences do |t|
+      t.integer :user_id
+      t.string :theme
+      t.integer :timezone, limit: 4
+      t.boolean :high_contrast
+      t.boolean :larger_text
+      t.boolean :ultimate_accessibility_mode
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/controllers/user_preference_controller_test.rb
+++ b/test/controllers/user_preference_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UserPreferenceControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/user_preferences.yml
+++ b/test/fixtures/user_preferences.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  theme: MyString
+  timezone: 1
+  high_contrast: false
+  larger_text: false
+  ultimate_accessibility_mode: false
+
+two:
+  user_id: 1
+  theme: MyString
+  timezone: 1
+  high_contrast: false
+  larger_text: false
+  ultimate_accessibility_mode: false

--- a/test/models/user_preference_test.rb
+++ b/test/models/user_preference_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserPreferenceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- Created NBGallery (User) Preferences
  - Users can now set their site theme to "dark", "grayscale", "ultra-dark", or "juicy".
  - Additional options to make all text bigger and make everything have more contrast. (Can be applied to default NBGallery skin or to one of the 4 themes mentions above).
- Did some catch up fixes
- Fixed a minor issue where internet explorer and microsoft edge browsers had a space in their css selector in the body class.
- Changed coloring of many links, almost all tags, and a handful of other elements to ensure all elements have appropriate contrast (accessibility).
- Changed NBGallery logo (image) to text.

-And have everything set up to support changing one's timezone or enabling ultimate accessibility mode, but unfortunately don't have time to fully implement them yet.

NOTE - did not test the themes on the reviews pages because I still haven't loaded them yet... Will apply manual fixes in a day or two.