### PR TITLE
User Link Tech Debt fix/cleanup and hover fix when user has no org

### DIFF
--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -3,6 +3,7 @@
     border-radius: 6px;
     padding-right: 0 !important;
     .modal-title {
+        margin: 0 !important;
         text-align: center;
     }
     .modal-header {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2023,11 +2023,18 @@ body.page-metrics {
     }
 }
 #notebookDisplay {
-    pre.highlight {
+    a.cell-health + span.sr-only + span.sr-only + hr.hidden + div pre.highlight {
         margin-top: -1.2em;
     }
     pre.highlight.highlight-text {
         margin-top: 0;
+    }
+    pre.highlight ~ img {
+        margin: 2px 2px 1em;
+    }
+    .stdout,
+    .stderr {
+        margin-bottom: 10px;
     }
     blockquote {
         background: $secondary-background;
@@ -2038,6 +2045,10 @@ body.page-metrics {
     }
     ul li p {
         margin: 0;
+    }
+    table.dataframe th,
+    table.dataframe td {
+        text-align: center;
     }
 }
 div.cellBad,
@@ -2662,23 +2673,85 @@ body.dark-theme {
         color: $text-color;
     }
     h1, h2, h3, h4, h5,
-    .modal .modal-content,
     #headerIcons > a > .glyphicon,
     #headerIcons > a > .caret,
     &.page-summary #main p,
     &.page-user_preferences #main p,
+    &.page-notebooks-learning #main p,
     #expandableSearch a,
+    #searchTable .sortData p,
+    #searchTable th,
     #headericons .nav-bar-icon,
     #headericons .nav-bar-icon:before,
     #headericons .nav-bar-icon:after,
-    #notebookDisplay p,
-    #changeReqView p,
-    #groupLanding p,
     #notebookJumbo p,
     .no-notebooks,
     .emptyNotebooks,
     p.empty {
         color: $secondary-background;
+    }
+    .popover-title {
+        color: #333;
+    }
+    #notebookDisplay,
+    #changeReqView,
+    #groupLanding {
+        p, strong, b, li, big, div {
+            color: $secondary-background;
+        }
+        pre.highlight {
+            background: #eee;
+            filter: invert(100%);
+        }
+        table th > strong {
+            color: initial;
+        }
+    }
+    #changeReqView {
+        li.del, li.del strong {
+            color: #b00;
+        }
+        li.ins, li.ins strong {
+            color: #080;
+        }
+        li.unchanged, li.unchanged strong {
+            color: $text-color;
+        }
+    }
+    #notebookDisplay {
+        div.stderr,
+        div.make-me-green {
+            color: $text-color;
+        }
+        div pre.highlight ~ img {
+            filter: invert(100%);
+        }
+        table.dataframe th {
+            background: #111;
+            color: $secondary-background;
+        }
+        .alert-info {
+            &, p, strong, b, li, big, div {
+                color: $info-alert-color;
+            }
+        }
+        .alert-success {
+            &, p, strong, b, li, big, div {
+                color: $success-alert-color;
+            }
+        }
+        .alert-warning {
+            &, p, strong, b, li, big, div {
+                color: $warning-alert-color;
+            }
+        }
+        .alert-danger,
+        .alert-err,
+        .alert-error {
+            &, p, strong, b, li, big, div {
+                color: $error-alert-color;
+            }
+        }
     }
     .modal .modal-header {
         background: $primary-border-color;
@@ -2702,7 +2775,7 @@ body.dark-theme {
     #topNavbar .logo-link .logo-nb {
         filter: invert(100%);
     }
-    .language-icon {
+    .language-icon[href*="/languages/python"] {
         filter: contrast(200%)invert(100%);
     }
     #expandableSearch:focus,
@@ -2723,19 +2796,14 @@ body.dark-theme {
     }
     table tbody tr:nth-child(odd),
     table tbody tr:nth-child(even) {
-        background: $intermediate-icon-color;
-    }
-    table.clean-table,
-    table.centered-table,
-    table#searchTable,
-    .modal table {
-        tbody tr:nth-child(odd),
-        tbody tr:nth-child(even) {
-            background: $secondary-background;
-        }
+        background: $secondary-background;
     }
     table th {
-        background: #bbb
+        background: #bbb;
+    }
+    table th,
+    table td {
+        border: 1px solid #999;
     }
     table.dataTable thead th.sorting {
         background: #bbb !important;
@@ -2750,6 +2818,11 @@ body.dark-theme {
         color: $text-color;
     }
     #nbTable tr:nth-child(even),
+    #searchTable tbody tr {
+        background: $intermediate-icon-color;
+    }
+    #nbTable tr:nth-child(odd),
+    #searchTable th,
     #notebookJumbo.info {
         background: #111;
     }
@@ -2763,10 +2836,6 @@ body.dark-theme {
         .badge  {
             color: $secondary-background;
         }
-    }
-    pre.highlight {
-        background: #eee;
-        filter: invert(100%);
     }
     #notebookJumbo {
         .glyphicon:not(.author-rep),
@@ -2792,6 +2861,68 @@ body.dark-theme {
         p,
         strong {
             color: $secondary-background;
+        }
+    }
+}
+
+/* ===== ULTRA DARK MODE ===== */
+body.ultra-dark-theme {
+    filter: saturate(150%)invert(100%);
+    &.path-video {
+        #wrapper {
+            background: #eee;
+        }
+        video {
+            filter: invert(100%);
+        }
+    }
+    .super-container {
+        filter: invert(100%)saturate(200%)contrast(120%);
+        .btn.search-submit {
+            color: #fff;
+        }
+    }
+    #topNavbar .logo-link .logo-nb {
+        color: #000;
+        filter: invert(100%);
+    }
+    .diff {
+        filter: invert(90%);
+    }
+    .alert,
+    .btn,
+    .github-fork-ribbon,
+    span.health,
+    .glyphicon-star,
+    .tag,
+    .carousel-inner,
+    .review-alert,
+    .open-reviews,
+    .author-rep,
+    div.stderr,
+    div.make-me-green,
+    .delete-icon,
+    .editEnvironment,
+    .review-statuses,
+    .review-icon-container,
+    .comment_delete_link,
+    .tagLogoLock {
+        filter: invert(100%);
+    }
+    &.page-languages #main li.list-group-item a[href*="/"]:not([href*="/languages/python"]) img,
+    .language-icon[href*="/"]:not([href*="/languages/python"]) {
+        filter: invert(100%);
+    }
+    #notebookDisplay,
+    #changeReqView,
+    #groupLanding {
+        img {
+            filter: invert(100%);
+        }
+        div.pre.highlight ~ img,
+        .alert img {
+            filter: invert(0);
+
         }
     }
 }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2023,7 +2023,8 @@ body.page-metrics {
     }
 }
 #notebookDisplay {
-    a.cell-health + span.sr-only + span.sr-only + hr.hidden + div pre.highlight {
+    a.cell-health + span.sr-only + span.sr-only + hr.hidden + div pre.highlight,
+    a.cell-health + span + span + span + span + span + hr.hidden + div pre.highlight {
         margin-top: -1.2em;
     }
     pre.highlight.highlight-text {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,6 @@ class UsersController < ApplicationController
   def reviews
     # Note: here we are showing reviews related to @viewed_user but only
     # those visible by the current user (@user)
-
     # Open Reviews done by @viewed_user
     reviews = @viewed_user.reviews.joins(:notebook)
     readable = Notebook.readable_join(reviews, @user, true)
@@ -143,7 +142,8 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @viewed_user.save
-        format.html {redirect_to @viewed_user, notice: 'User was successfully created.'}
+        format.html {redirect_to @viewed_user}
+        flash[:success] = "User was successfully created."
         format.json {render :show, status: :created, location: @viewed_user}
       else
         format.html {render :new}
@@ -159,7 +159,8 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @viewed_user.update(user_params)
-        format.html {redirect_to @viewed_user, success: 'User was successfully updated.'}
+        format.html {redirect_to @viewed_user}
+        flash[:success] = "User was successfully updated."
         format.json {render :show, status: :ok, location: @viewed_user}
       else
         format.html {render :edit}
@@ -172,7 +173,8 @@ class UsersController < ApplicationController
   def destroy
     @viewed_user.destroy
     respond_to do |format|
-      format.html {redirect_to users_url, notice: 'User was successfully destroyed.'}
+      format.html {redirect_to users_url}
+      flash[:success] = "User was successfully destroyed."
       format.json {head :no_content}
     end
   end
@@ -184,7 +186,8 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       @user.skip_reconfirmation!
       #sign_in(@user, :bypass => true)
-      redirect_to @user, notice: 'Your profile was successfully updated.'
+      redirect_to @user
+      flash[:success] = "Your profile was successfully updated."
     else
       @show_errors = true
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -159,7 +159,7 @@ class UsersController < ApplicationController
 
     respond_to do |format|
       if @viewed_user.update(user_params)
-        format.html {redirect_to @viewed_user, notice: 'User was successfully updated.'}
+        format.html {redirect_to @viewed_user, success: 'User was successfully updated.'}
         format.json {render :show, status: :ok, location: @viewed_user}
       else
         format.html {render :edit}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,7 +88,11 @@ module ApplicationHelper
   end
 
   def link_to_user(user)
-    link_to(user.name, user)
+    if user.org.length > 0
+      link_to(user.name, user, class: "tooltips", title: "#{user.name} (#{user.org})")
+    else
+      link_to(user.name, user)
+    end
   end
 
   def link_to_group(group)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -88,7 +88,7 @@ module ApplicationHelper
   end
 
   def link_to_user(user)
-    if user.org.length > 0
+    if user.org != nil && user.org.length > 0
       link_to(user.name, user, class: "tooltips", title: "#{user.name} (#{user.org})")
     else
       link_to(user.name, user)

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -49,7 +49,7 @@ table.content.table-responsive id="nbTable"
               -if nb.owner.is_a? User
                 ==render partial: "author_rep_trophy_icon", locals: {author: nb.owner}
                 span.sr-only #{" "}
-                a.tooltips href="#{user_path(nb.owner)}" title="#{nb.owner.first_name} #{nb.owner.last_name} (#{nb.owner.org})" ==nb.owner.name
+                ==link_to_user(nb.owner)
               -else
                 a.tooltips href="#{group_path(nb.owner)}" title="Group: #{nb.owner.name}" ==nb.owner.name
               span.hidden aria-hidden="true" #{" | "}
@@ -61,7 +61,7 @@ table.content.table-responsive id="nbTable"
                 '  by
                 ==render partial: "author_rep_trophy_icon", locals: {author: nb.creator}
                 span.sr-only #{" "}
-                a.tooltips href="#{user_path(nb.creator)}" title="#{nb.creator.first_name} #{nb.creator.last_name} (#{nb.creator.org})" =="#{nb.creator.first_name} #{nb.creator.last_name}"
+                ==link_to_user(nb.creator)
               -else
                 span.table_footer_authored Last updated:
                 -@revisions = nb.revision_list(@user)
@@ -76,7 +76,7 @@ table.content.table-responsive id="nbTable"
                 '  by
                 ==render partial: "author_rep_trophy_icon", locals: {author: nb.updater}
                 span.sr-only #{" "}
-                a.tooltips href="#{user_path(nb.updater)}" title="#{nb.updater.first_name} #{nb.updater.last_name} (#{nb.updater.org})" =="#{nb.updater.first_name} #{nb.updater.last_name}"
+                ==link_to_user(nb.updater)
             hr.divider.show style="display: none"
               -unless nb.snippet(@user).blank?
                 span.sr-only

--- a/app/views/change_requests/index.slim
+++ b/app/views/change_requests/index.slim
@@ -37,7 +37,7 @@ div.content-container
                   -if entry.status == 'pending'
                     ==link_to('Review', entry)
                 td
-                  a.tooltips href="#{user_path(entry.requestor)}" title="#{entry.requestor.first_name} #{entry.requestor.last_name} (#{entry.requestor.org})" =="#{entry.requestor.first_name} #{entry.requestor.last_name}"
+                  ==link_to_user(entry.requestor)
                   -unless entry.requestor_comment.blank?
                     -unless entry.status != 'pending'
                       span.glyphicon.glyphicon-comment.tooltips title="#{entry.requestor_comment}" style='margin-left:5px'
@@ -71,7 +71,7 @@ div.content-container
                   ==link_to_notebook(entry.notebook)
                 td
                   -owner = User.find(entry.notebook.owner.id)
-                  a.tooltips href="#{user_path(owner)}" title="#{owner.first_name} #{owner.last_name} (#{owner.org})" =="#{owner.first_name} #{owner.last_name}"
+                  ==link_to_user(owner)
                 td
                   -if entry.status == 'pending'
                     ==link_to('View Request', entry)

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -47,6 +47,7 @@ html lang="en"
             filter: grayscale(100%);
           }
       -elsif user_pref.theme == "ultra-dark"
+        -ultra_dark = TRUE
         css:
           body {
             filter: saturate(150%)invert(100%)
@@ -68,6 +69,7 @@ html lang="en"
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
   -body_classes += "dark-theme " if dark == TRUE
+  -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE
   -if request.path == "/"
     -body_classes += "page-home "

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -48,14 +48,6 @@ html lang="en"
           }
       -elsif user_pref.theme == "ultra-dark"
         -ultra_dark = TRUE
-        css:
-          body {
-            filter: saturate(150%)invert(100%)
-          }
-          #topNavbar .logo-link .logo-nb {
-              color: #000;
-              filter: invert(100%);
-          }
       -if user_pref.high_contrast == TRUE
         css:
           html {

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -47,6 +47,7 @@ html lang="en"
             filter: grayscale(100%);
           }
       -elsif user_pref.theme == "ultra-dark"
+        -ultra_dark = TRUE
         css:
           body {
             filter: saturate(150%)invert(100%)
@@ -68,6 +69,7 @@ html lang="en"
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
   -body_classes += "dark-theme " if dark == TRUE
+  -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE
   -if request.path == "/"
     -body_classes += "page-home "

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -48,14 +48,6 @@ html lang="en"
           }
       -elsif user_pref.theme == "ultra-dark"
         -ultra_dark = TRUE
-        css:
-          body {
-            filter: saturate(150%)invert(100%)
-          }
-          #topNavbar .logo-link .logo-nb {
-              color: #000;
-              filter: invert(100%);
-          }
       -if user_pref.high_contrast == TRUE
         css:
           html {

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -165,7 +165,7 @@ div.content-container
             time.tooltips.tooltip-right.tooltipstered title="#{@notebook.created_at.strftime('%A, %B %d, %Y %H:%M UTC')}"
               | #{time_ago_in_words(@notebook.created_at)} ago
             '  by
-            a.tooltips href="#{user_path(@notebook.creator)}" title="#{@notebook.creator.first_name} #{@notebook.creator.last_name} (#{@notebook.creator.org})" =="#{@notebook.creator.first_name} #{@notebook.creator.last_name}"
+            ==link_to_user(@notebook.creator)
             span.sr-only #{" "}
             ==render partial: "author_rep_trophy_icon", locals: { author: @notebook.creator }
           -else
@@ -173,7 +173,7 @@ div.content-container
             time.tooltips.tooltip-right.tooltipstered title="#{@notebook.content_updated_at.strftime('%A, %B %d, %Y %H:%M UTC')}"
               | #{time_ago_in_words(@notebook.content_updated_at)} ago
             '  by
-            a.tooltips href="#{user_path(@notebook.updater)}" title="#{@notebook.updater.first_name} #{@notebook.updater.last_name} (#{@notebook.updater.org})" =="#{@notebook.updater.first_name} #{@notebook.updater.last_name}"
+            ==link_to_user(@notebook.updater)
             span.sr-only #{" "}
             ==render partial: "author_rep_trophy_icon", locals: { author: @notebook.updater }
           -if @notebook.owner.is_a? Group

--- a/app/views/stages/show.slim
+++ b/app/views/stages/show.slim
@@ -3,8 +3,9 @@ div.content-container id="stageView"
   div.center
     h1 Staged notebook view
     p
-      strong Author:#{" "}
-      a href="#{user_path(@stage.user)}" #{@stage.user.name}
+      strong
+        ' Author:
+      ==link_to_user(@stage.user)
     p
       strong Submitted:
       time.tooltips.tooltip-right.tooltipstered title="#{@stage.created_at.strftime("%A, %B %d, %Y %H:%M UTC")}"

--- a/app/views/users/detail.slim
+++ b/app/views/users/detail.slim
@@ -1,7 +1,7 @@
 div.content-container
   h1.center
     ' Details for
-    a href="#{user_path(@viewed_user)}" #{@viewed_user.name}
+    ==link_to_user(@viewed_user)
   br
   div.row
     div.col-md-5

--- a/app/views/users/groups.slim
+++ b/app/views/users/groups.slim
@@ -1,6 +1,6 @@
 div.content-container
   h1
-    a href="#{user_path(@viewed_user)}" #{@viewed_user.name}
+    ==link_to_user(@viewed_user)
     | 's Groups
   a.dropdownGroup.modal-activate href="#" data-target="#newGroup" data-toggle="modal" tabindex="-1"
     button.btn.btn-primary.createGroup Create Group

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -12,7 +12,7 @@ div.content-container
   div
     h1
       span #{@viewed_user.name}
-      -if @viewed_user.org.length > 0
+      -if @viewed_user.org != nil && @viewed_user.org.length > 0
         span #{" "}
         span aria-hidden="true" #{"("}
         span.sr-only

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -12,6 +12,13 @@ div.content-container
   div
     h1
       span #{@viewed_user.name}
+      -if @viewed_user.org.length > 0
+        span #{" "}
+        span aria-hidden="true" #{"("}
+        span.sr-only
+          ' Org:
+        span ==@viewed_user.org
+        span aria-hidden="true" #{")"}
       span.sr-only #{" "}
       ==render partial: 'author_rep_trophy_icon', locals: { author: @viewed_user }
     hr.divider


### PR DESCRIPTION
- Changed all user links to use the link_to_user helper and included logic for displaying org on title if they exist for said user (so removed a bit of tech debt too)
- Changed the notice flash messages to success flash messages when doing user model changes.
- Is too wordy to include "belongs to org: Engineering" for all user links for screenreader users so decided to just add it to the header on the User Summary page (so a minor change there too).
- Did some catch up for the dark and ultra dark themes

Tested everything but confirming the success message appears after a user is created and their profile is updated, but it does work every time for updating users and creating users and it was of the same code format.