### PR TITLE
Accessibility-8: Fixed tab order appearances for the recommendations section on the notebook jumbrotron, added additional screenreader text in a number of places, and fixed an issue where the Cancel button on the notebook edit fields (e.g. title, tags, and description) were not tab-able.

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1637,6 +1637,9 @@ p.description {
     .slick-next:before {
         color: #fff;
     }
+    button.slick-arrow:focus {
+        outline: 1px dotted #ccc;
+    }
     .slick-dots {
         top: 107px;
         button {
@@ -1721,6 +1724,9 @@ p.description {
         position: absolute;
         top: -23.5px;
     }
+    .notebook-description:focus .glyphicon-info-sign {
+        color: $secondary-link-color;
+    }
     .footerShelf .glyphicon-fire {
         font-size: 14px;
         left: 30px;
@@ -1738,6 +1744,16 @@ p.description {
         position: absolute;
         top: 95px;
         width: 66px;
+    }
+    a.nounderline:focus p,
+    a.nounderline:hover p {
+        text-decoration: underline;
+    }
+    .language-icon:focus {
+        outline: none;
+        img {
+            outline: 1px dotted $primary-link-color;
+        }
     }
 }
 .slick-dots li.slick-active button:before,

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -68,8 +68,10 @@ table.content.table-responsive id="nbTable"
                 -(@revisions + [nil]).each_cons(2) do |rev, previous|
                   -if previous && rev.commit_id != previous.commit_id
                     -most_recent_comparison_path = diff_notebook_revision_path(nb, previous, revision: rev.commit_id)
+                    span.sr-only #{" "}
                     a.update-link.tooltips.tooltipstered href="#{most_recent_comparison_path}" title="Notebook version (diff) comparison highlighting recent changes made"
-                      span.glyphicon.glyphicon-edit.tooltips.nounderline
+                      span.glyphicon.glyphicon-edit.tooltips.nounderline aria-hidden="true"
+                      span.sr-only View changes from last update
                     -break
                 time.tooltips.tooltip-right.tooltipstered title="#{nb.content_updated_at.strftime("%A, %B %d, %Y %H:%M UTC")}"
                   |  #{time_ago_in_words(nb.content_updated_at)} ago
@@ -85,7 +87,12 @@ table.content.table-responsive id="nbTable"
             div.tagRow
               -nb.tags.first(10).each do |tag|
                 a href="/tags/#{tag.tag}"
-                  span.label.tag style="font-size: 13px; font-family: calibri; color: #fff; background-color: #{color_for(tag.tag)}" ==tag.tag
+                  span.label.tag style="font-size: 13px; font-family: calibri; color: #fff; background-color: #{color_for(tag.tag)}"
+                    span.sr-only Tag of
+                    span.hidden aria-hidden="true" #{":"}
+                    span.sr-only #{" \""}
+                    ==tag.tag
+                    span.sr-only #{"\""}
                 span.hidden aria-hidden="true" #{" "}
               -if nb.tags.size > 10
                 a href="#{url_for(nb)}"

--- a/app/views/application/_notebook_metadata_metrics.slim
+++ b/app/views/application/_notebook_metadata_metrics.slim
@@ -47,13 +47,16 @@
     span.badge.badge-notify =notebook.shares.size
     span.hidden aria-hidden="true" #{")"}
   span.hidden aria-hidden="true" #{" | "}
-a.tooltips href="#{metrics_notebook_path(notebook)}#metricsHealth" title="#{notebook.notebook_summary.health_description}"
+a.tooltips href="#{metrics_notebook_path(notebook)}#metricsHealth" title=(notebook.notebook_summary.health_description == nil ? "Undetermined Health: Notebook has not been executed yet" : "#{notebook.notebook_summary.health_description}")
   -if notebook.unhealthy?
     span.fa.fa-medkit.action-icon.view-summary.health.unhealthy
     span.sr-only ==notebook.notebook_summary.health_description
   -elsif notebook.healthy?
     span.fa.fa-medkit.action-icon.view-summary.health.healthy
     span.sr-only ==notebook.notebook_summary.health_description
+  -elsif notebook.notebook_summary.health_description == nil
+    span.fa.fa-medkit.action-icon.view-summary.health.healthUnknown
+    span.sr-only Undetermined Health: Notebook has not been executed yet
   -else
     span.fa.fa-medkit.action-icon.view-summary.health.healthUnknown
     span.sr-only ==notebook.notebook_summary.health_description

--- a/app/views/application/_notebook_tile_small.slim
+++ b/app/views/application/_notebook_tile_small.slim
@@ -9,7 +9,7 @@ div.info.square
       ==render partial: 'language_icons', locals: { notebook: notebook }
       span.sr-only
         '  Notebook description:
-      a.nounderline href="#{notebook_path(notebook)}"
+      a.nounderline.notebook-description href="#{notebook_path(notebook)}"
         i.glyphicon.glyphicon-info-sign.tooltip-narrow title="#{notebook.description}"
         span.sr-only ==notebook.description
       -if defined? last_viewed

--- a/app/views/application/_tags_edit.slim
+++ b/app/views/application/_tags_edit.slim
@@ -3,9 +3,9 @@ div.tags id="tagsEdit" style="display: none"
   form id="tagsEditForm" enctype="multipart/form-data" role="form"
     div.input-group data-toggle="tooltip" title="Enter tags here"
       input.form-control id="editTags" type="text" value=notebook.tags.pluck(:tag).join(",") name="tags"
-    div class="form-group edit-buttons"
+    div.form-group.edit-buttons
       button.btn.btn-success id="tagsEditSubmit" style="float:left" Update
       a id="tagsEditCancel" data-turbolinks="false"
-        button.btn.btn-danger tabindex="-1" Cancel
+        button.btn.btn-danger Cancel
   div.tag-edit-mode
     ==render partial: "notebook_metadata", locals: { notebook: notebook }

--- a/app/views/application/_tags_view.slim
+++ b/app/views/application/_tags_view.slim
@@ -4,7 +4,12 @@ div.tags.mouseoveredit id="tagsDisplay"
   div.tagRow
     -notebook.tags.each do |tag|
       a href="/tags/#{tag.tag}"
-        span.label.tag style="background-color: #{color_for(tag.tag)}" ==tag.tag
+        span.label.tag style="background-color: #{color_for(tag.tag)}"
+          span.sr-only Tag of
+          span.hidden aria-hidden="true" #{":"}
+          span.sr-only #{" \""}
+          ==tag.tag
+          span.sr-only #{"\""}
       span.hidden aria-hidden="true" #{" "}
     a.glyphicon.glyphicon-pencil.tooltips href="#" id="tagsEditPencil" title="Add or edit tags"
       span.sr-only #{" "}

--- a/app/views/modals/_approve_change_request.slim
+++ b/app/views/modals/_approve_change_request.slim
@@ -5,7 +5,7 @@ div.modal.fade.notebookModalsSmall id="approveChangeRequestModal" aria-modal="tr
       p.sr-only id="approveChangeRequestDescription" Dialog for approving change requests for notebooks
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="approveChangeRequestForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         ==render partial: "custom_change_request_approval_fields"

--- a/app/views/modals/_cancel_change_request.slim
+++ b/app/views/modals/_cancel_change_request.slim
@@ -5,7 +5,7 @@ div.modal.fade.notebookModalsSmall id="cancelChangeRequestModal" aria-labelledby
       p.sr-only id="cancelChangeRequestDescription" Dialog for canceling change requests for notebooks
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="cancelChangeRequestForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         div.form-group.has-feedback

--- a/app/views/modals/_decline_change_request.slim
+++ b/app/views/modals/_decline_change_request.slim
@@ -5,7 +5,7 @@ div.modal.fade.notebookModalsSmall id="declineChangeRequestModal" aria-labelledb
       p.sr-only id="declineChangeRequestDescription" Dialog for declining change requests for notebooks
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="declineChangeRequestForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         div.form-group.has-feedback

--- a/app/views/modals/_login_modal.slim
+++ b/app/views/modals/_login_modal.slim
@@ -4,7 +4,7 @@ div.modal.fade.in id="login-modal" aria-labelledby="loginHeader" aria-describedb
       ==image_tag("nbgallery_logo.png")
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
       div.tab-pane.fade.in.active id="login-content" role="tabpanel"
         h1 id="loginHeader" Login to Your Account
         p.sr-only id="loginDescription" Dialog for logging in, resetting password, and registering a new #{GalleryConfig.site.name} account.

--- a/app/views/modals/_manage_group.slim
+++ b/app/views/modals/_manage_group.slim
@@ -7,7 +7,7 @@ div.modal.fade id="manageGroup" aria-labelledby="manageGroupHeader" aria-describ
           p.sr-only id="manageGroupDescription" Dialog for managing your group
           button.close type="button" data-dismiss="modal"
             span aria-hidden="true" &times;
-            span.sr-only Close
+            span.sr-only Close Dialog
         div.modal-body
           div.form-group.has-feedback
             div.input-group

--- a/app/views/modals/_new_group.slim
+++ b/app/views/modals/_new_group.slim
@@ -7,7 +7,7 @@ div.modal.fade id="newGroup" aria-labelledby="newGroupHeader" aria-describedby="
           p.sr-only id="newGroupDescription" Dialog for creating a new group
           button.close type="button" data-dismiss="modal"
             span aria-hidden="true" &times;
-            span.sr-only Close
+            span.sr-only Close Dialog
         div.modal-body
           div.form-group.has-feedback
             div.input-group

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -7,7 +7,7 @@ div.modal.fade id="sharingModal" aria-labelledby="shareHeader" aria-describedby=
           p.sr-only id="shareDescription" Dialog for sharing a notebook with other users
           button.close type="button" data-dismiss="modal"
             span aria-hidden="true" &times;
-            span.sr-only Close
+            span.sr-only Close Dialog
         div.modal-body
           div.alert.alert-info.modal-alert
             i.fa.fa-info-circle aria-hidden="true"
@@ -35,12 +35,15 @@ div.modal.fade id="commentsModal" aria-labelledby="commentHeader" aria-described
         p.sr-only id="commentDescription" Dialog for viewing and creating new comments on the notebook
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         div id="commentsSection"
           ==commontator_thread(@notebook)
         div.modal-footer
-          button.btn.btn-danger data-dismiss="modal" Close
+          button.btn.btn-danger data-dismiss="modal"
+            | Close
+            span.sr-only
+              |  Dialog
 
 div.modal.fade id="changeOwnerModal" aria-labelledby="changeOwnerHeader" aria-describedby="changeOwnerDescription" role="dialog" style="display: none" tabindex="0"
   div.modal-dialog
@@ -51,7 +54,7 @@ div.modal.fade id="changeOwnerModal" aria-labelledby="changeOwnerHeader" aria-de
           p.sr-only id="changeOwnerDescription" Dialog for granting ownership of your notebook from you to a group for example
           button.close type="button" data-dismiss="modal"
             span aria-hidden="true" &times;
-            span.sr-only Close
+            span.sr-only Close Dialog
         div.modal-body
           div.alert.alert-danger.center hidden="true" id="changeOwnerErrorWarning"
           div.form-group
@@ -73,7 +76,7 @@ div.modal.fade.notebookModalsSmall id="editNotebookModal" aria-labelledby="editM
       p.sr-only id="editNotebookDescription"
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="editUploadForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         div.alert.alert-danger.text-center hidden="true" id="editUploadErrorWarning"
@@ -104,7 +107,7 @@ div.modal.fade.notebookModalsSmall id="stageEdit" aria-labelledby="stageEditModa
       p.sr-only id="stageEditDescription"
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="stageEditForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         div.alert.alert-danger.text-center hidden="true" id="editStageErrorWarning"
@@ -141,7 +144,7 @@ div.modal.fade.notebookModalsSmall id="feedbackModal" aria-labelledby="provideFe
       p.sr-only id="provideFeedbackDescription" Dialog for submitting feedback about the notebook to the owner or owners to read
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       form id="feedbackForm" enctype="multipart/form-data" data-toggle="validator" role="form"
         div.alert.alert-danger.center hidden="true" id="uploadErrorWarning"
@@ -189,7 +192,7 @@ div.modal.fade id="showNotebookUUIDModal" aria-labelledby="showNotebookUUIDHeade
         p.sr-only id="showNotebookUUIDDescription" Dialog displaying notebook's universal unique identifier string
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         p
           | The notebook UUID is
@@ -199,4 +202,7 @@ div.modal.fade id="showNotebookUUIDModal" aria-labelledby="showNotebookUUIDHeade
           span.uuid ==@notebook.uuid
         div.modal-footer
           div
-            button.btn.btn-danger type="button" data-dismiss="modal" Close
+            button.btn.btn-danger data-dismiss="modal"
+              | Close
+              span.sr-only
+                |  Dialog

--- a/app/views/modals/_notebook_metric_details.slim
+++ b/app/views/modals/_notebook_metric_details.slim
@@ -6,7 +6,7 @@ div.modal.fade id='metricsViews' aria-labelledby="notebookViewsHeader" aria-desc
         p.sr-only id="notebookViewsDescription" Dialog for sharing a notebook with other users
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         table.centered-table.table.tabular.datatable
           caption.sr-only Notebook Views by User
@@ -25,7 +25,10 @@ div.modal.fade id='metricsViews' aria-labelledby="notebookViewsHeader" aria-desc
                   td #{info[:last]}
         div.modal-footer
           div
-            button.btn.btn-danger type="button" data-dismiss="modal" Close
+            button.btn.btn-danger data-dismiss="modal"
+              | Close
+              span.sr-only
+                |  Dialog
 
 div.modal.fade id='metricsRuns' aria-labelledby="notebookRunsHeader" aria-describedby="notebookRunsDescription" role='dialog' style="display: none" tabindex="0"
   div.modal-dialog.modal-lg
@@ -35,7 +38,7 @@ div.modal.fade id='metricsRuns' aria-labelledby="notebookRunsHeader" aria-descri
         p.sr-only id="notebookRunsDescription" Dialog for sharing a notebook with other users
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         table.centered-table.table.tabular.datatable
           caption.sr-only Notebook Runs by User
@@ -54,20 +57,23 @@ div.modal.fade id='metricsRuns' aria-labelledby="notebookRunsHeader" aria-descri
                   td #{info[:last]}
         div.modal-footer
           div
-            button.btn.btn-danger type="button" data-dismiss="modal" Close
+            button.btn.btn-danger data-dismiss="modal"
+              | Close
+              span.sr-only
+                |  Dialog
 
 div.modal.fade id='metricsStars' aria-labelledby="notebookStarsHeader" aria-describedby="notebookStarsDescription" role='dialog' style="display: none" tabindex="0"
   div.modal-dialog.modal-lg
     div.modal-content
       div.modal-header
-        h1.modal-title id="notebookStarsHeader" Notebook Stars by User
+        h1.modal-title id="notebookStarsHeader" Users who have Starred this Notebook
         p.sr-only id="notebookStarsDescription" Dialog for sharing a notebook with other users
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         table.centered-table.table.tabular.datatable
-          caption.sr-only Notebook Stars by User
+          caption.sr-only Users who have Starred this Notebook
           thead
             tr
               th User
@@ -81,20 +87,23 @@ div.modal.fade id='metricsStars' aria-labelledby="notebookStarsHeader" aria-desc
                   td 1
         div.modal-footer
           div
-            button.btn.btn-danger type="button" data-dismiss="modal" Close
+            button.btn.btn-danger data-dismiss="modal"
+              | Close
+              span.sr-only
+                |  Dialog
 
 div.modal.fade id='metricsEdits' aria-labelledby="notebookEditsHeader" aria-describedby="notebookEditsDescription" role='dialog' style="display: none" tabindex="0"
   div.modal-dialog.modal-lg
     div.modal-content
       div.modal-header
-        h1.modal-title id="notebookEditsHeader" Edits of Notebook by User
+        h1.modal-title id="notebookEditsHeader" Notebook's Edit History
         p.sr-only id="notebookEditsDescription" Dialog for sharing a notebook with other users
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         table.centered-table.table.tabular.editHistory
-          caption.sr-only Edits of Notebook by User
+          caption.sr-only Notebook's Edit History
           thead
             tr
               th User
@@ -114,4 +123,7 @@ div.modal.fade id='metricsEdits' aria-labelledby="notebookEditsHeader" aria-desc
                   td =edit.updated_at
         div.modal-footer
           div
-            button.btn.btn-danger type="button" data-dismiss="modal" Close
+            button.btn.btn-danger data-dismiss="modal"
+              | Close
+              span.sr-only
+                |  Dialog

--- a/app/views/modals/_upload.slim
+++ b/app/views/modals/_upload.slim
@@ -5,7 +5,7 @@ div.modal.fade.notebookModalsSmall id="uploadFileModal" aria-labelledby="uploadF
       p.sr-only id="uploadFileDescription" Dialog one of two for uploading a new notebook. Upload file and accept terms and conditions
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       ==form_tag "/stages", id: "uploadFileForm", enctype: "multipart/form-data", "data-toggle": "validator", role: "form" do
         div.alert.alert-danger.center hidden="true" id="uploadErrorWarning"
@@ -28,7 +28,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
       p.sr-only id="stageUploadDescription" Dialog two of two for uploading a new notebook. Add title, description, tags, make private applicable, etcetera
       button.close type="button" data-dismiss="modal"
         span aria-hidden="true" &times;
-        span.sr-only Close
+        span.sr-only Close Dialog
     div.modal-body
       ==form_tag "/notebooks", id: "stageForm", enctype: "multipart/form-data", "data-toggle": "validator", role: "form"
         div.alert.alert-danger.center hidden="true" id="stageErrorWarning"

--- a/app/views/modals/_view_group.slim
+++ b/app/views/modals/_view_group.slim
@@ -6,7 +6,7 @@ div.modal.fade id="viewGroup" aria-labelledby="viewGroupHeader" aria-describedby
         p.sr-only id="viewGroupDescription" Read-only dialog showing the users of group
         button.close type="button" data-dismiss="modal"
           span aria-hidden="true" &times;
-          span.sr-only Close
+          span.sr-only Close Dialog
       div.modal-body
         table.table.order-list
           caption.sr-only Group Members

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -22,8 +22,8 @@ div.content-container
               textarea.form-control id="editTitle" type="text" name="title" ==@notebook.title
             div.form-group.edit-buttons
               button.btn.btn-success id="titleEditSubmit" type="submit" style="float:left" Update
-              a href="#" id="titleEditCancel" data-turbolinks="false"
-                button.btn.btn-danger tabindex="-1" Cancel
+              a id="titleEditCancel" data-turbolinks="false"
+                button.btn.btn-danger Cancel
 
     hr.divider.show style="display: none"
     div class=(@notebook.reviews.length > 1 ? "information-container flex" : "information-container noflex" )
@@ -197,11 +197,11 @@ div.content-container
             span.sr-only Edit description
     form id="descriptionEditForm" enctype="multipart/form-data" role="form" style="display: none"
       div.input-group data-toggle="tooltip" title="Edit description here"
-        textarea id="descriptionField"==@notebook.description
-      div class="form-group edit-buttons"
+        textarea id="descriptionField" ==@notebook.description
+      div.form-group.edit-buttons
         button.btn.btn-success id="descriptionEditSubmit" style="float:left" Update
         a id="descriptionEditCancel" data-turbolinks="false"
-          button.btn.btn-danger tabindex="-1" Cancel
+          button.btn.btn-danger Cancel
       span.error.hidden id="descriptionError"
     div.center
       a.tooltips href="#" id="recommendationToggle" aria-label="Toggle reveal of recommended notebooks listing" title="Toggle recommended notebooks"

--- a/app/views/notebooks/notebook_metrics.slim
+++ b/app/views/notebooks/notebook_metrics.slim
@@ -27,6 +27,8 @@ div.content-container
           a.modal-activate href='#' data-target='#metricsViews' data-toggle='modal'
             div.panel-footer
               span.pull-left View Details
+              span.sr-only
+                |  of Notebook Views by User
               span.pull-right
                 i.glyphicon.glyphicon.expand
               div.clearfix
@@ -42,6 +44,8 @@ div.content-container
           a.modal-activate href='#' data-target='#metricsRuns' data-toggle='modal'
             div.panel-footer
               span.pull-left View Details
+              span.sr-only
+                |  of Notebook Runs by User
               span.pull-right
                 i.glyphicon.glyphicon.expand
               div.clearfix
@@ -57,6 +61,8 @@ div.content-container
           a.modal-activate href='#' data-target='#metricsStars' data-toggle='modal'
             div.panel-footer
               span.pull-left View Details
+              span.sr-only
+                |  of who has Starred this Notebook
               span.pull-right
                 i.glyphicon.glyphicon.expand
               div.clearfix
@@ -72,6 +78,8 @@ div.content-container
           a.modal-activate href='#' data-target='#metricsEdits' data-toggle='modal'
             div.panel-footer
               span.pull-left View Details
+              span.sr-only
+                |  of this Notebook's Edit History
               span.pull-right
                 i.glyphicon.glyphicon.expand
               div.clearfix

--- a/app/views/reviews/show.slim
+++ b/app/views/reviews/show.slim
@@ -18,7 +18,7 @@ div.content-container
           -url = diff_notebook_revision_path(@review.notebook, previous, revision: @review.revision)
           span aria-hidden="true"  (
           a.tooltips href="#{url}" title="Notebook version (diff) comparison highlighting recent changes made"
-            i.fa.fa-files-o
+            i.fa.fa-files-o aria-hidden="true"
             span.sr-only Notebook version diff comparison highlighting recent changes made
           span aria-hidden="true" )
     p

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -39,12 +39,12 @@ div.content-container
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Start Date
-            input.form-control.tooltips type="text" name="min_date" placeholder="12/31/1999" title="Start Date" required=true id='summaryTimeStart' value="#{params[:min_date]}"
+            input.form-control.tooltips type="text" name="min_date" placeholder="1999-12-31" title="Start Date" required=true id='summaryTimeStart' value="#{params[:min_date]}"
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon End Date
-            input.form-control.tooltips type="text" name="max_date" placeholder="12/31/2099" title="End Date" required=true id='summaryTimeEnd' value="#{params[:max_date]}"
+            input.form-control.tooltips type="text" name="max_date" placeholder="2099-12-31" title="End Date" required=true id='summaryTimeEnd' value="#{params[:max_date]}"
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.button-container
           a


### PR DESCRIPTION
Fixed tab order appearances for the recommendations section on the notebook jumbrotron, added additional screenreader text in a number of places, and fixed an issue where the Cancel button on the notebook edit fields (e.g. title, tags, and description) were not tab-able.

All has been tested