### PR TITLE
Recommendations-url-fix: Fixed the issue where on cleaning up tech debt, we kiss the url parameter for reccomended pages so tracking how many people clicked is harder

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -37,24 +37,28 @@ class StaticPagesController < ApplicationController
     home_notebooks
   end
 
-  #new beta homepage layout
+  # Homepage Layout
   def home_notebooks
-    #recommendation list for the user
-    if params[:type] == 'suggested' or (@user.member? and params[:type].nil?)
+    # Recommendation list for the user
+    if (params[:type] == 'suggested' or params[:type].nil?) and @user.member?
       @notebooks = @user.notebook_recommendations.order('score DESC').first(Notebook.per_page)
       locals = { ref: 'suggested' }
-    #recent
-    elsif params[:type] == 'recent' or params[:type].nil?
+    # List of all notebooks
+    elsif params[:type] == 'all' or params[:type].nil?
+      @notebooks = query_notebooks
+      locals = { ref: 'all' }
+    # Recent
+    elsif params[:type] == 'recent'
       @sort = :created_at
       @notebooks = query_notebooks
       locals = { ref: 'home_recent' }
-    #newsfeed
-    elsif params[:type] == 'updated'
-      @sort = :updated_at
-      @notebooks = query_notebooks
-      locals = { ref: 'updated' }
-    #USER notebooks
-    elsif params[:type] == 'mine'
+    # Newsfeed
+    #elsif params[:type] == 'updated'
+      #@sort = :updated_at
+      #@notebooks = query_notebooks
+      #locals = { ref: 'updated' }
+    # User's notebooks
+    elsif params[:type] == 'mine' and @user.member?
       @sort = :updated_at
       @notebooks = query_notebooks.where(
         "(owner_type='User' AND owner_id=?) OR (creator_id=?) OR (updater_id=?)",
@@ -63,11 +67,7 @@ class StaticPagesController < ApplicationController
         @user.id
       )
       locals = { ref: 'home_updated' }
-    #a list of all notebooks
-    elsif params[:type] == 'all'
-      @notebooks = query_notebooks
-      locals = { ref: 'all' }
-    #starred notebooks
+    # Starred notebooks
     elsif params[:type] == 'stars'
       @notebooks = query_notebooks.where(id: @user.stars.pluck(:id))
       locals = { ref: 'stars' }

--- a/app/views/application/_table_nb_title.slim
+++ b/app/views/application/_table_nb_title.slim
@@ -6,7 +6,7 @@ span.sr-only
 span.hidden aria-hidden="true"
   | :
 span.sr-only #{" "}
-a.title href=((params[:type] == nil || params[:type] == "suggested") && request.path == "/home_notebooks" ? "#{url_for(nb)}?ref=suggested" : "#{url_for(nb)}")
+a.title href=((params[:type] == nil || params[:type] == "suggested") && @user.member? && request.path == "/home_notebooks" ? "#{url_for(nb)}?ref=suggested" : "#{url_for(nb)}")
   -unless nb.public?
     ==image_tag("Lock.png", class: "tagLogoLock tooltips tooltipstered show-inline", title: "This notebook is private", aria: {"hidden": true}, style:"display: none")
   ==nb.title

--- a/app/views/application/_table_nb_title.slim
+++ b/app/views/application/_table_nb_title.slim
@@ -6,7 +6,7 @@ span.sr-only
 span.hidden aria-hidden="true"
   | :
 span.sr-only #{" "}
-a.title href="#{url_for(nb)}"
+a.title href=((params[:type] == nil || params[:type] == "suggested") && request.path == "/home_notebooks" ? "#{url_for(nb)}?ref=suggested" : "#{url_for(nb)}")
   -unless nb.public?
     ==image_tag("Lock.png", class: "tagLogoLock tooltips tooltipstered show-inline", title: "This notebook is private", aria: {"hidden": true}, style:"display: none")
   ==nb.title

--- a/app/views/static_pages/home.slim
+++ b/app/views/static_pages/home.slim
@@ -17,16 +17,18 @@
         ==image_tag("nbgallery_logo.png", class:"center ld ld-breath logo-loading", alt:"Content is loading")
       nav.main.content id="txt"
         ul.tabs
+          -if @user.member?
+            li.tab
+              a.tabLink.active href="#" aria-label="Show notebooks recommended for me" aria-expanded="true" id="newHomeNotebooksRecommended" Recommended
           li.tab
-            a.tabLink.active href="#" aria-label="Show notebooks recommended for me" aria-expanded="false" id="newHomeNotebooksRecommended" Recommended
-          li.tab
-            a.tabLink href="#" aria-label="Show all notebooks" aria-expanded="false" id="newHomeNotebooksAll" All Notebooks
+            a.tabLink class=(@user.member? ? "" : "active") href="#" aria-label="Show all notebooks" aria-expanded=(@user.member? ? "false" : "true") id="newHomeNotebooksAll" All Notebooks
           li.tab
             a.tabLink href="#" aria-label="Show notebooks recently viewed" aria-expanded="false" id="newHomeNotebooksRecent" Recent Notebooks
-          li.tab
-            a.tabLink href="#" aria-label="Show my notebooks" aria-expanded="false" id="newHomeNotebooksYours" My Notebooks
-          li.tab
-            a.tabLink href="#" aria-label="Show all of my stars notebooks" aria-expanded="false" id="newHomeNotebooksStars" Starred Notebooks
+          -if @user.member?
+            li.tab
+              a.tabLink href="#" aria-label="Show my notebooks" aria-expanded="false" id="newHomeNotebooksYours" My Notebooks
+            li.tab
+              a.tabLink href="#" aria-label="Show all of my stars notebooks" aria-expanded="false" id="newHomeNotebooksStars" Starred Notebooks
         div id="newHomePageNotebooks"
           div role="alert"
             ==image_tag("nbgallery_logo.png", class:"center ld ld-breath logo-loading", id:"initialLoadImage", alt:"Content is loading")


### PR DESCRIPTION
Recommendations-url-fix: Fixed the issue where on cleaning up tech debt, we kiss the url parameter for reccomended pages so tracking how many people clicked is harder

Was able to test it on another environment, but on this environment, I couldn't test it because I don't have any recommendations for some reason. I have tested to make sure the links that shouldn't get the param aren't getting it though.