### PR TITLE
Accessibility-9: Made it so all header elements and dropdowns across the product can now be opened with either 'enter' or 'space' and made it so canceling the editor for the notebook title, tags, or description does not force the page to reload

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -11,7 +11,8 @@ document.addEventListener("turbolinks:load", function(){
   /* ===================================== */
   $('#mobileNavContainer').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#mobileNavContainer').click();
     }
   });
@@ -33,7 +34,8 @@ document.addEventListener("turbolinks:load", function(){
   });
   $('#gearDropdown').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#gearDropdown').click();
     }
   });
@@ -50,10 +52,12 @@ document.addEventListener("turbolinks:load", function(){
     closeMoreMenu();
     closeNotebooksDropdown();
     closeSearch();
+    return false;
   });
   $('#learnMore').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#learnMore').click();
     }
   });
@@ -106,7 +110,8 @@ document.addEventListener("turbolinks:load", function(){
   }
   $('#dropdownCaretButton').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#dropdownCaretButton').click();
     }
   });
@@ -129,7 +134,8 @@ document.addEventListener("turbolinks:load", function(){
   /* ======================================= */
   $('#expandableSearch').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#expandableSearch').click();
     }
   });
@@ -164,7 +170,8 @@ document.addEventListener("turbolinks:load", function(){
   });
   $('a.switchGUI').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('a.switchGUI').click();
     }
   });
@@ -218,14 +225,11 @@ document.addEventListener("turbolinks:load", function(){
     });
   }
 
-  $('.page-change_requests-id #changeReqViewText').on("click", function(){
-    loadingGif();
-  });
-
   //Data for RECENT notebooks
   $('#newHomeNotebooksRecent').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#newHomeNotebooksRecent').click();
     }
   });
@@ -238,7 +242,8 @@ document.addEventListener("turbolinks:load", function(){
   //Data for STARRED notebooks
   $('#newHomeNotebooksStars').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#newHomeNotebooksStars').click();
     }
   });
@@ -251,7 +256,8 @@ document.addEventListener("turbolinks:load", function(){
   //Data for RECOMMENDED notebooks
   $('#newHomeNotebooksRecommended').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#newHomeNotebooksRecommended').click();
     }
   });
@@ -264,7 +270,8 @@ document.addEventListener("turbolinks:load", function(){
    //Data for YOUR notebooks
   $('#newHomeNotebooksYours').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#newHomeNotebooksYours').click();
     }
   });
@@ -277,7 +284,8 @@ document.addEventListener("turbolinks:load", function(){
   //Data for ALL notebooks
   $('#newHomeNotebooksAll').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#newHomeNotebooksAll').click();
     }
   });
@@ -310,7 +318,8 @@ document.addEventListener("turbolinks:load", function(){
   });
   $('#groupToggle').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
       $('#groupToggle').click();
     }
   });
@@ -382,6 +391,14 @@ document.addEventListener("turbolinks:load", function(){
     $('#sortResultsForm').submit();
   }).val($('#sortHidden').val());
 
+  //More Actions Dropdown for Notebook
+  $('#notebookGearDropdown').keypress(function(e){
+    var keycode = (e.keyCode ? event.keyCode : event.which);
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
+      $('#notebookGearDropdown').click();
+    }
+  });
   $('#notebookGearDropdown').click(function() {
     $(this).toggleClass('expand');
     if($(this).hasClass('expand')){
@@ -390,6 +407,30 @@ document.addEventListener("turbolinks:load", function(){
     else {
       $('#notebookGearActions').css("display","none");
     }
+    toggleAriaExpanded(this);
+    return false;
+  });
+
+  /* Changes Requests */
+  $('#changeReqViewButton').keypress(function(e){
+    var keycode = (e.keyCode ? event.keyCode : event.which);
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
+      $('#changeReqViewButton').click();
+    }
+  });
+  $('#changeReqViewButton').click(function() {
+    $(this).toggleClass('expand');
+    if($(this).hasClass('expand')){
+      $('#changeReqViewDropdown').css("display","block");
+    }
+    else {
+      $('#changeReqViewDropdown').css("display","none");
+    }
+    toggleAriaExpanded(this);
+  });
+  $('.page-change_requests-id #changeReqViewText').on("click", function(){
+    loadingGif();
   });
 
   /* Have Modals gain focus whenever opened - in the event of default behavior failing */
@@ -536,8 +577,9 @@ document.addEventListener("turbolinks:load", function(){
 
   $('#recommendationToggle').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
-    if(keycode == '13'){
-      $('#recommendationToggle').click(); //Trigger recommendation toggle Click
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
+      $('#recommendationToggle').click();
     }
   });
   $('#recommendationToggle').on('click', function(event){
@@ -553,6 +595,7 @@ document.addEventListener("turbolinks:load", function(){
       });
     }
     $(this).children('i').toggleClass('spin');
+    toggleAriaExpanded(this);
   });
 });
 

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -32,14 +32,14 @@ document.addEventListener("turbolinks:load", function(){
     closeUserDropdown();
     toggleAriaExpanded(this);
   });
-  $('#gearDropdown').keypress(function(e){
+  $('body.user-signed-in #gearDropdown').keypress(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
     if(keycode == '13' || keycode == '32'){
       e.preventDefault();
       $('#gearDropdown').click();
     }
   });
-  $('#gearDropdown').click(function() {
+  $('body.user-signed-in #gearDropdown').click(function() {
     $(this).toggleClass('open');
     $('#gearDropdownMenu').toggleClass('expand');
     if($(this).hasClass('open')){

--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -52,7 +52,6 @@ document.addEventListener("turbolinks:load", function(){
       $('#titleView').toggle();
       $('#titleEdit').toggle();
     }
-    location.reload();
   });
 
   if (pathname.indexOf("/nb/") > -1 || pathname.indexOf("/notebook/") > -1 || pathname.indexOf("/notebooks/") > -1){
@@ -90,7 +89,6 @@ document.addEventListener("turbolinks:load", function(){
     event.preventDefault();
     $('#tagsDisplay').toggle();
     $('#tagsEdit').toggle();
-    location.reload();
   });
 
   $('#tagsEditSubmit').click(function(){
@@ -133,7 +131,6 @@ document.addEventListener("turbolinks:load", function(){
     event.preventDefault();
     $('#descriptionEditForm').toggle();
     $('#descriptionView').toggle();
-    location.reload();
   });
 
   $('#descriptionEditSubmit').click(function(){

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1133,7 +1133,7 @@ body.page-revisions-id .alert.revision-page-alert {
 }
 #nbTable #snippetInfo {
     font-family: $secondary-font-family;
-    font-size: 80%;
+    font-size: 10pt;
     margin: .2em 0;
 }
 #hiddenSpinner {
@@ -2930,6 +2930,9 @@ body.ultra-dark-theme {
     .tagLogoLock {
         filter: invert(100%);
     }
+    &.page-users-id .carousel-inner .author-rep {
+        filter: invert(0);
+    }
     &.page-languages #main li.list-group-item a[href*="/"]:not([href*="/languages/python"]) img,
     .language-icon[href*="/"]:not([href*="/languages/python"]) {
         filter: invert(100%);
@@ -2940,10 +2943,9 @@ body.ultra-dark-theme {
         img {
             filter: invert(100%);
         }
-        div.pre.highlight ~ img,
+        div pre.highlight ~ img,
         .alert img {
             filter: invert(0);
-
         }
     }
 }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -658,7 +658,7 @@ span.review-alert {
     border-top: 1px solid #bbb;
     bottom: 0;
     display: none;
-    height: 150%;
+    height: calc(100vh - 59px);
     left: 0;
     position: absolute;
     right: 0;

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -1,4 +1,4 @@
-table.content.table-responsive id="nbTable"
+table.content.table-responsive id="nbTable" role="presentation"
   caption.sr-only Notebook Listings
   thead.sr-only
     tr

--- a/app/views/application/not_modern_browser.slim
+++ b/app/views/application/not_modern_browser.slim
@@ -1,5 +1,5 @@
 div.content-container.center
-  div.alert.alert-danger id="ErrorLayout"
+  div.alert.alert-danger id="errorLayout"
     h1
       | Unsupported Browser
       span aria-hidden="true" #{":"}

--- a/app/views/change_requests/show.slim
+++ b/app/views/change_requests/show.slim
@@ -163,10 +163,12 @@ div.content-container
     ==render partial: 'custom_change_request_warning'
     div.center
       div.btn-group
-        button.btn.btn-primary.dropdown-toggle data-toggle='dropdown'
-          span id='changeReqViewText' Compare Notebooks
+        button.btn.btn-primary.dropdown-toggle id="changeReqViewButton" aria-haspopup="true" aria-expanded="false"
+          span id="changeReqViewText" Compare Notebooks
+          span.sr-only
+            |  View Dropdown
           span.caret
-        ul.dropdown-menu
+        ul.dropdown-menu id="changeReqViewDropdown" style="display: none"
           li
             a href ='#' id='changeReqViewCompare'
               span Compare Notebooks
@@ -177,7 +179,7 @@ div.content-container
             a href ='#' id='changeReqViewInlineDiffs'
               span View Diffs (inline)
     hr
-    div.row id = 'changeReqView'
+    div.row id="changeReqView"
   -else
     div.center
       h2 This change request was #{@change_request.status} #{time_ago_in_words(@change_request.updated_at)} ago

--- a/app/views/change_requests/show.slim
+++ b/app/views/change_requests/show.slim
@@ -99,6 +99,7 @@ javascript:
       $('#changeReqView').removeClass('view-inline view-compare').addClass('view-diffs');
       $('#changeReqView').load('#{diff_change_request_path(@change_request)}');
       $(this).parents('.dropdown-menu').dropdown('toggle');
+      $('#changeReqViewButton').click();
       return false;
     });
 
@@ -108,6 +109,7 @@ javascript:
       $('#changeReqView').removeClass('view-diffs view-compare').addClass('view-inline');
       $('#changeReqView').load('#{diff_inline_change_request_path(@change_request)}');
       $(this).parents('.dropdown-menu').dropdown('toggle');
+      $('#changeReqViewButton').click();
       return false;
     });
 
@@ -117,6 +119,7 @@ javascript:
       $('#changeReqView').removeClass('view-diffs view-inline').addClass('view-compare');
       $('#changeReqView').load('#{compare_change_request_path(@change_request)}');
       $(this).parents('.dropdown-menu').dropdown('toggle');
+      $('#changeReqViewButton').click();
       return false;
     });
   });

--- a/app/views/change_requests/show.slim
+++ b/app/views/change_requests/show.slim
@@ -128,7 +128,7 @@ div.content-container
       i.fa.fa-share aria-hidden="true"
       | See all your change requests
   h1.center
-    span id='title'
+    span id="title"
       ' Change Request for:
       ==link_to_notebook(@change_request.notebook)
   div.page-metadata
@@ -145,22 +145,22 @@ div.content-container
       strong Comments:
       |  #{@change_request.requestor_comment}
     div.button-container
-      -if @change_request.status == 'pending'
+      -if @change_request.status == "pending"
         -if @user.can_edit?@change_request.notebook
-          a.modal-activate href="#approveChangeRequestModal" data-toggle='modal' tabindex="-1"
+          a.modal-activate href="#approveChangeRequestModal" data-toggle="modal" tabindex="-1"
             button.btn.btn-success Approve Change Request
-          a.modal-activate href="#declineChangeRequestModal" data-toggle='modal' tabindex="-1"
+          a.modal-activate href="#declineChangeRequestModal" data-toggle="modal" tabindex="-1"
             button.btn.btn-danger Decline Change Request
         -if @change_request.requestor == @user
-          a.modal-activate href="#cancelChangeRequestModal" data-toggle='modal' tabindex="-1"
+          a.modal-activate href="#cancelChangeRequestModal" data-toggle="modal" tabindex="-1"
             button.btn.btn-danger Cancel Request
 
-  -if @change_request.status == 'pending'
+  -if @change_request.status == "pending"
     -if @change_request.updated_at < @change_request.notebook.updated_at
       div.alert.alert-danger.center
         span
           strong Warning: Notebook has been modified since this change request was submitted
-    ==render partial: 'custom_change_request_warning'
+    ==render partial: "custom_change_request_warning"
     div.center
       div.btn-group
         button.btn.btn-primary.dropdown-toggle id="changeReqViewButton" aria-haspopup="true" aria-expanded="false"
@@ -170,13 +170,13 @@ div.content-container
           span.caret
         ul.dropdown-menu id="changeReqViewDropdown" style="display: none"
           li
-            a href ='#' id='changeReqViewCompare'
+            a href ="#" id="changeReqViewCompare"
               span Compare Notebooks
           li
-            a href ='#' id='changeReqViewDiffs'
+            a href ="#" id="changeReqViewDiffs"
               span View Diffs
           li
-            a href ='#' id='changeReqViewInlineDiffs'
+            a href ="#" id="changeReqViewInlineDiffs"
               span View Diffs (inline)
     hr
     div.row id="changeReqView"

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -117,7 +117,7 @@ html lang="en"
                         button.btn.search-submit tabindex="4"
                           span.glyphicon.glyphicon-search
                             span.sr-only Search
-                        input.searchFieldBox.form-control type="text" placeholder="Search" name="q" value="#{params[:q] || ''}" tabindex="3"
+                        input.searchFieldBox.form-control type="search" placeholder="Search" name="q" value="#{params[:q] || ''}" tabindex="3"
                         input type="hidden" name="sort" value="score"
                     span.dropdown.navbar-right id="headerIcons"
                       -if request.path != "/"
@@ -251,7 +251,7 @@ html lang="en"
                         li id="learnMoreLink"
                           a href="#" rel="external" What is Jupyter?
                       br.hidden
-                      a.dropdown-toggle href="#" data-toggle="dropdown" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
+                      a.dropdown-toggle href="#" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
                         span.sr-only Toggle User Dropdown
                         -if @user.member?
                           -sql_statement = "reviewer_id = #{@user.id} and status = 'claimed'"
@@ -378,7 +378,7 @@ html lang="en"
                   button.btn.search-submit
                     span.glyphicon.glyphicon-search
                       span.sr-only Search
-                  input.searchFieldBox.form-control type="text" placeholder="Search" name="q" value="#{params[:q] || ''}"
+                  input.searchFieldBox.form-control type="search" placeholder="Search" name="q" value="#{params[:q] || ''}"
                   input type="hidden" name="sort" value="score"
         -if @warning != nil
           div class = "alert center #{@warning.level == "warning" ? "alert-danger" : "alert-info"}" id="galleryWarning" role="banner"

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -60,6 +60,8 @@ html lang="en"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} browser-modern-#{browser.modern?} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes += "user-anonymous " if !@user.member?
+  -body_classes += "user-signed-in " if @user.member?
   -body_classes += "dark-theme " if dark == TRUE
   -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE
@@ -106,7 +108,7 @@ html lang="en"
                         button.btn.btn-primary.navbar-btn Upload
                     div.btn-group id="notebookFilterDropDownFullThing"
                       button.navbar-btn.btn.btn-primary.tooltips title="View all notebooks" id="notebookFilterDropDown" href="/notebooks" onclick="window.location = '/notebooks'"  Notebooks
-                      button.navbar-btn.btn.btn-primary.dropdown-toggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" type="button" id="dropdownCaretButton"
+                      button.navbar-btn.btn.btn-primary.dropdown-toggle aria-haspopup="true" aria-expanded="false" type="button" id="dropdownCaretButton"
                         | &nbsp;
                         span.caret
                         span.sr-only Toggle Dropdown
@@ -251,7 +253,7 @@ html lang="en"
                         li id="learnMoreLink"
                           a href="#" rel="external" What is Jupyter?
                       br.hidden
-                      a.dropdown-toggle href="#" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
+                      a.dropdown-toggle href="#" id="gearDropdown" data-toggle=(@user.member? ? "" : "dropdown") aria-haspopup="true" aria-expanded="false"
                         span.sr-only Toggle User Dropdown
                         -if @user.member?
                           -sql_statement = "reviewer_id = #{@user.id} and status = 'claimed'"

--- a/app/views/layouts/beta_layout.slim
+++ b/app/views/layouts/beta_layout.slim
@@ -60,8 +60,10 @@ html lang="en"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} browser-modern-#{browser.modern?} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
-  -body_classes += "user-anonymous " if !@user.member?
-  -body_classes += "user-signed-in " if @user.member?
+  -if @user.member?
+    -body_classes += "user-signed-in "
+  -else
+    -body_classes += "user-anonymous "
   -body_classes += "dark-theme " if dark == TRUE
   -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -117,7 +117,7 @@ html lang="en"
                         button.btn.search-submit tabindex="4"
                           span.glyphicon.glyphicon-search
                             span.sr-only Search
-                        input.searchFieldBox.form-control type="text" placeholder="Search" name="q" value="#{params[:q] || ''}" tabindex="3"
+                        input.searchFieldBox.form-control type="search" placeholder="Search" name="q" value="#{params[:q] || ''}" tabindex="3"
                         input type="hidden" name="sort" value="score"
                     span.dropdown.navbar-right id="headerIcons"
                       -if request.path != "/"
@@ -251,7 +251,7 @@ html lang="en"
                         li id="learnMoreLink"
                           a href="#" rel="external" What is Jupyter?
                       br.hidden
-                      a.dropdown-toggle href="#" data-toggle="dropdown" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
+                      a.dropdown-toggle href="#" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
                         span.sr-only Toggle User Dropdown
                         -if @user.member?
                           -sql_statement = "reviewer_id = #{@user.id} and status = 'claimed'"
@@ -378,7 +378,7 @@ html lang="en"
                   button.btn.search-submit
                     span.glyphicon.glyphicon-search
                       span.sr-only Search
-                  input.searchFieldBox.form-control type="text" placeholder="Search" name="q" value="#{params[:q] || ''}"
+                  input.searchFieldBox.form-control type="search" placeholder="Search" name="q" value="#{params[:q] || ''}"
                   input type="hidden" name="sort" value="score"
         -if @warning != nil
           div class = "alert center #{@warning.level == "warning" ? "alert-danger" : "alert-info"}" id="galleryWarning" role="banner"

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -60,6 +60,8 @@ html lang="en"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} browser-modern-#{browser.modern?} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
+  -body_classes += "user-anonymous " if !@user.member?
+  -body_classes += "user-signed-in " if @user.member?
   -body_classes += "dark-theme " if dark == TRUE
   -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE
@@ -106,7 +108,7 @@ html lang="en"
                         button.btn.btn-primary.navbar-btn Upload
                     div.btn-group id="notebookFilterDropDownFullThing"
                       button.navbar-btn.btn.btn-primary.tooltips title="View all notebooks" id="notebookFilterDropDown" href="/notebooks" onclick="window.location = '/notebooks'"  Notebooks
-                      button.navbar-btn.btn.btn-primary.dropdown-toggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" type="button" id="dropdownCaretButton"
+                      button.navbar-btn.btn.btn-primary.dropdown-toggle aria-haspopup="true" aria-expanded="false" type="button" id="dropdownCaretButton"
                         | &nbsp;
                         span.caret
                         span.sr-only Toggle Dropdown
@@ -251,7 +253,7 @@ html lang="en"
                         li id="learnMoreLink"
                           a href="#" rel="external" What is Jupyter?
                       br.hidden
-                      a.dropdown-toggle href="#" id="gearDropdown" aria-haspopup="true" aria-expanded="false"
+                      a.dropdown-toggle href="#" id="gearDropdown" data-toggle=(@user.member? ? "" : "dropdown") aria-haspopup="true" aria-expanded="false"
                         span.sr-only Toggle User Dropdown
                         -if @user.member?
                           -sql_statement = "reviewer_id = #{@user.id} and status = 'claimed'"

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -60,8 +60,10 @@ html lang="en"
   -browser = Browser.new(request.env["HTTP_USER_AGENT"])
   -url_check = request.path.split("/")
   -body_classes = "browser-#{browser.name.downcase.gsub(" ","-")} browser-full-#{browser.name.downcase.gsub(" ","-")}-#{browser.version} browser-modern-#{browser.modern?} platform-#{browser.platform.name.downcase} platform-full-#{browser.platform.name.downcase}-#{browser.platform.version} "
-  -body_classes += "user-anonymous " if !@user.member?
-  -body_classes += "user-signed-in " if @user.member?
+  -if @user.member?
+    -body_classes += "user-signed-in "
+  -else
+    -body_classes += "user-anonymous "
   -body_classes += "dark-theme " if dark == TRUE
   -body_classes += "ultra-dark-theme " if ultra_dark == TRUE
   -body_classes += "larger-text-mode " if larger_text == TRUE

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -73,7 +73,7 @@ div.content-container
             span.hidden aria-hidden="true" #{" | "}
 
             -if @user.can_read?(@notebook)
-              a.dropdown-toggle.tooltips href="#" id="notebookGearDropdown" data-toggle="dropdown" title="More Options" aria-haspopup="true" aria-expanded="false"
+              a.dropdown-toggle.tooltips href="#" id="notebookGearDropdown" title="More Options" aria-haspopup="true" aria-expanded="false"
                 span.sr-only Toggle More Options Dropdown
                 span.glyphicon.glyphicon-cog.action-icon aria-hidden="true"
                   b.caret
@@ -204,7 +204,7 @@ div.content-container
           button.btn.btn-danger tabindex="-1" Cancel
       span.error.hidden id="descriptionError"
     div.center
-      a.tooltips href="#" id="recommendationToggle" aria-label="Toggle reveal of recommended notebooks listing" title="Toggle recommended notebooks"
+      a.tooltips href="#" id="recommendationToggle" aria-haspopup="true" aria-expanded="false" aria-label="Toggle reveal of recommended notebooks listing" title="Toggle recommended notebooks"
         span.sr-only
           ' Toggle
         span Recommendations

--- a/app/views/static_pages/home.slim
+++ b/app/views/static_pages/home.slim
@@ -10,7 +10,7 @@
               button.btn.search-submit tabindex="4"
                 span.glyphicon.glyphicon-search
                   span.sr-only Search
-              input.searchFieldBox.form-control name="q" placeholder="Search" type="text" value="" tabindex="3"
+              input.searchFieldBox.form-control name="q" placeholder="Search" type="search" value="" tabindex="3"
               input name="sort" type="hidden" value="score"
     section.content-container id="main" role="main"
       div id="hiddenSpinner" role="alert"


### PR DESCRIPTION
Accessibility-9: Made it so all header elements and dropdowns across the product can now be opened with either 'enter' or 'space' and made it so canceling the editor for the notebook title, tags, or description does not force the page to reload. In addition added type of search to all search bars because although we probably won't see much happen, it is listed as a potential accessibility improvement and users could maybe do internal searches of a site from their browser url address bar after tabbing one time (if everything is set up right?)

I have tested and it all works the same as always for search and have made sure the rest work given these new requirements.