### PR TITLE
Support markdown in descriptions including auto-linking but leave as …

### DIFF
--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -190,7 +190,11 @@ div.content-container
         | :
       span.sr-only #{" "}
       p class="description #{@user.can_edit?(@notebook) || @user.admin? ? 'edit_area' : ''}" id="description"
-        ==@notebook.description
+        -if GalleryConfig.markdown != nil && GalleryConfig.markdown.description_enabled
+          -markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true)
+          ==markdown.render(@notebook.description)
+        -else
+          ==@notebook.description
       -if @user.can_edit?(@notebook) || @user.admin?
         a.edit-icon id="editDescription" href="#"
           span.glyphicon.glyphicon-pencil.tooltips title="Edit description"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -107,6 +107,10 @@ slim:
   table_nb_title: table_nb_title
   table_nb_description: table_nb_description
 
+# Markdown prefereces
+markdown:
+  description_enabled: false
+
 # Run in Jupyter Preferences
 run_in_jupyter:
   no_instance_title: No Jupyter Instance


### PR DESCRIPTION
…disabled by default 
This would address #31 but also not change existing behavior in installed instances since it defaults to false.