### PR TITLE
Accessibility tech debt and helped provide more quick links for admin users

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2016,14 +2016,6 @@ body.page-groups-id a.landing-page-link.delete-icon {
 body.page-groups-id #groupLanding {
     margin-top: 2em;
 }
-#editGroup span.glyphicon,
-#groupInfo span.glyphicon {
-    font-size: 25px;
-    margin-left: 5px;
-    @media all and (max-width: 800px) {
-        font-size: 18px;
-    }
-}
 body.page-groups-id .carousel-caption h1,
 body.directory-languages .carousel-caption h1,
 body.page-notebooks .carousel-caption h1.long-title,
@@ -2205,6 +2197,35 @@ body.page-users-id .carousel-caption .glyphicon-equalizer {
     @media all and (max-width: 800px) {
         font-size: 18px;
     }
+}
+.carousel-caption .glyphicon-pencil,
+.carousel-caption #groupInfo span.glyphicon,
+.carousel-caption #userDetailLink i {
+    font-size: 24px;
+    margin-left: 5px;
+    top: 0;
+    @media all and (max-width: 800px) {
+        font-size: 17px;
+    }
+}
+.carousel-caption #userDetailLink i {
+    position: relative;
+    top: -1px;
+}
+body.page-summary h1 .glyphicon-pencil,
+body.page-summary h1 #userDetailLink i {
+    font-size: 19px;
+    margin-left: 2px;
+    position: relative;
+    top: 2px;
+    &:hover,
+    &:focus {
+        color: $secondary-link-color;
+    }
+}
+body.page-summary h1 #userDetailLink i {
+    font-size: 20px;
+    top: 1px;
 }
 body.page-summary .author-rep {
     font-size: 18px;
@@ -2517,6 +2538,9 @@ body.page-change_requests {
         padding: 0;
         text-align: right;
     }
+}
+.glyphicon-alert {
+    color: #f2c253;
 }
 
 /* ===== Change Request Page (/change_requests/{ID}) - Show ===== */
@@ -3062,7 +3086,8 @@ body.ultra-dark-theme {
     .tagLogoLock,
     a.skip,
     &.page-home .tabs .tabLink.active,
-    .logo-loading {
+    .logo-loading,
+    .glyphicon-alert {
         filter: invert(100%);
     }
     &.page-users-id .carousel-inner .author-rep {
@@ -3087,6 +3112,9 @@ body.ultra-dark-theme {
 
 /* ===== LARGER TEXT MODE ===== */
 body.larger-text-mode {
+    .home-search-container .glyphicon-search {
+        top: -1px;
+    }
     .carousel-caption h1,
     &.page-notebooks .carousel-caption h1.long-title {
         font-size: 5vw;

--- a/app/views/application/_author_rep_trophy_icon.slim
+++ b/app/views/application/_author_rep_trophy_icon.slim
@@ -2,15 +2,15 @@ span.hidden aria-hidden="true" #{"["}
 a href="#{summary_user_path(author)}"
   -if author.author_rep_pct
     -if author.author_rep_pct >= 90
-      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-gold.tooltips title="Author contribution score: #{author.author_rep_pct.floor}"
+      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-gold.tooltips aria-hidden="true" title="Author contribution score: #{author.author_rep_pct.floor}"
     -elsif author.author_rep_pct >= 75
-      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-silver.tooltips title="Author contribution score: #{author.author_rep_pct.floor}"
+      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-silver.tooltips aria-hidden="true" title="Author contribution score: #{author.author_rep_pct.floor}"
     -elsif author.author_rep_pct >= 50
-      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-bronze.tooltips title="Author contribution score: #{author.author_rep_pct.floor}"
+      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-bronze.tooltips aria-hidden="true" title="Author contribution score: #{author.author_rep_pct.floor}"
     -else
-      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-white.tooltips title="Author contribution score: #{author.author_rep_pct.floor}"
+      span.glyphicon.glyphicon-equalizer.author-rep.author-rep-white.tooltips aria-hidden="true" title="Author contribution score: #{author.author_rep_pct.floor}"
     span.sr-only Author with contribution score of #{author.author_rep_pct.floor}
   -else
-    span.glyphicon.glyphicon-equalizer.author-rep.author-rep-white.tooltips title="Author contribution score: 0"
+    span.glyphicon.glyphicon-equalizer.author-rep.author-rep-white.tooltips aria-hidden="true" title="Author contribution score: 0"
     span.sr-only Author with contribution score of 0
 span.hidden aria-hidden="true" #{"]"}

--- a/app/views/groups/show.slim
+++ b/app/views/groups/show.slim
@@ -11,14 +11,14 @@ div.content-container.mobile-expanding
               span.sr-only #{" "}
               span.hidden aria-hidden="true" #{"["}
               a.nounderline.modal-activate href="#" id="editGroup" data-target="#manageGroup" data-toggle="modal"
-                span.glyphicon.glyphicon-pencil.tooltips title="Edit Group Members"
+                span.glyphicon.glyphicon-pencil.tooltips aria-hidden="true" title="Edit Group Members"
                 span.sr-only Edit group members
               span.hidden aria-hidden="true" #{"]"}
             -else
               span.sr-only #{" "}
               span.hidden aria-hidden="true" #{"["}
               a.nounderline.modal-activate href="#" id="groupInfo" data-target="#viewGroup" data-toggle="modal"
-                span.glyphicon.glyphicon-user.tooltips title="View Group Members"
+                span.glyphicon.glyphicon-user.tooltips aria-hidden="true" title="View Group Members"
                 span.sr-only View group members
               span.hidden aria-hidden="true" #{"]"}
             span.sr-only #{" "}
@@ -27,11 +27,11 @@ div.content-container.mobile-expanding
             span.hidden aria-hidden="true" #{"["}
             -if has_sub > 0
               a.nounderline href="#{subscriptions_path}/#{sub.pluck("id").first}" ref="nofollow" data-method="delete" id="subscriptionToggle"
-                i.fa.fa-rss.tooltips style="color: #eec905" title="Unsubscribe from this group"
+                i.fa.fa-rss.tooltips style="color: #eec905" aria-hidden="true" title="Unsubscribe from this group"
                 span.sr-only Unsubscribe from this group
             -else
               a.nounderline href="#{new_subscription_path}?subid=#{@group.id}&type=group" ref="nofollow" data-method="patch" id="subscriptionToggle"
-                i.fa.fa-rss.tooltips title="Subscribe to this group"
+                i.fa.fa-rss.tooltips aria-hidden="true" title="Subscribe to this group"
                 span.sr-only Subscribe to this group
             span.hidden aria-hidden="true" #{"]"}
           p.lead

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -227,7 +227,7 @@ div.modal.fade.notebookModalsSmall id="feedbackModal" aria-labelledby="provideFe
         div.modal-footer
           div
             button.btn.btn-danger type="button" data-dismiss="modal" Cancel
-            button type="submit" id="feedbackSubmit" class="btn btn-success" Submit
+            button.btn.btn-success type="submit" id="feedbackSubmit" Submit
           div id="feedbackProgressBar"
 
 div.modal.fade id="showNotebookUUIDModal" aria-labelledby="showNotebookUUIDHeader" aria-describedby="showNotebookUUIDDescription" role="dialog" style="display: none" tabindex="0"

--- a/app/views/tags/show.slim
+++ b/app/views/tags/show.slim
@@ -12,10 +12,10 @@ div.content-container.mobile-expanding
               span.hidden aria-hidden="true" #{"["}
               -if has_sub > 0
                 a.nounderline href="#{subscriptions_path}/#{sub.pluck("id").first}" ref="nofollow" data-method="delete" id="subscriptionToggle"
-                  i.fa.fa-rss.tooltips style="color: #eec905;" title='Unsubscribe from examples (tag:"trusted")'
+                  i.fa.fa-rss.tooltips style="color: #eec905" aria-hidden="true" title='Unsubscribe from examples (tag:"trusted")'
               -else
                 a.nounderline.tooltips href="#{new_subscription_path}?subid=#{@tag.id}&type=tag" ref="nofollow" data-method="patch" id="subscriptionToggle"
-                  i.fa.fa-rss.tooltips title='Subscribe to examples (tag:"trusted")'
+                  i.fa.fa-rss.tooltips aria-hidden="true" title='Subscribe to examples (tag:"trusted")'
               span.hidden aria-hidden="true" #{"]"}
             p.lead Learn from examples of how to use Jupyter with Python, Ruby, R, C++ and others.
           -else
@@ -24,10 +24,10 @@ div.content-container.mobile-expanding
               span.sr-only #{" "}
               -if has_sub > 0
                 a.nounderline href="#{subscriptions_path}/#{sub.pluck("id").first}" ref="nofollow" data-method="delete" id="subscriptionToggle"
-                  i.fa.fa-rss.tooltips style="color: #eec905;" title="Unsubscribe from this tag"
+                  i.fa.fa-rss.tooltips style="color: #eec905" aria-hidden="true" title="Unsubscribe from this tag"
                   span.sr-only Unsubscribe from this tag
               -else
                 a.nounderline.tooltips href="#{new_subscription_path}?subid=#{@tag.id}&type=tag" ref="nofollow" data-method="patch" id="subscriptionToggle"
-                  i.fa.fa-rss.tooltips title="Subscribe to this tag"
+                  i.fa.fa-rss.tooltips aria-hidden="true" title="Subscribe to this tag"
                   span.sr-only Subscribe to this tag
 ==render partial: 'notebooks'

--- a/app/views/users/show.slim
+++ b/app/views/users/show.slim
@@ -14,11 +14,21 @@ div.content-container.mobile-expanding
             span.hidden aria-hidden="true" #{"["}
             -if has_sub > 0
               a.nounderline href="#{subscriptions_path}/#{sub.pluck("id").first}" ref="nofollow" data-method="delete" id="subscriptionToggle"
-                i.fa.fa-rss.tooltips style="color:#eec905;" title="Unsubscribe from this user"
+                i.fa.fa-rss.tooltips style="color:#eec905" aria-hidden="true" title="Unsubscribe from this user"
                 span.sr-only Unsubscribe from this user
             -else
               a.nounderline href="#{new_subscription_path}?subid=#{@viewed_user.id}&type=user" ref="nofollow" data-method="patch" id="subscriptionToggle"
-                i.fa.fa-rss.tooltips title="Subscribe to this user"
+                i.fa.fa-rss.tooltips aria-hidden="true" title="Subscribe to this user"
                 span.sr-only Subscribe to this user
             span.hidden aria-hidden="true" #{"]"}
+            -if @user.admin?
+              span.hidden aria-hidden="true" #{" ["}
+              a.nounderline href="#{detail_user_path(@viewed_user)}" id="userDetailLink"
+                i.fa.fa-pie-chart.tooltips aria-hidden="true" title="User Details"
+                span.sr-only User Details
+              span.hidden aria-hidden="true" #{"] ["}
+              a.nounderline href="#{edit_user_path(@viewed_user)}" id="userEditLink"
+                i.glyphicon.glyphicon-pencil.tooltips aria-hidden="true" title="Edit User"
+                span.sr-only Edit User
+              span.hidden aria-hidden="true" #{"]"}
 ==render partial: 'notebooks'

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -21,6 +21,16 @@ div.content-container
         span aria-hidden="true" #{")"}
       span.sr-only #{" "}
       ==render partial: "author_rep_trophy_icon", locals: { author: @viewed_user }
+      -if @user.admin?
+        span.hidden aria-hidden="true" #{" ["}
+        a.nounderline href="#{detail_user_path(@viewed_user)}" id="userDetailLink"
+          i.fa.fa-pie-chart.tooltips aria-hidden="true" title="User Details"
+          span.sr-only User Details
+        span.hidden aria-hidden="true" #{"] ["}
+        a.nounderline href="#{edit_user_path(@viewed_user)}" id="userEditLink"
+          i.glyphicon.glyphicon-pencil.tooltips aria-hidden="true" title="Edit User"
+          span.sr-only Edit User
+        span.hidden aria-hidden="true" #{"]"}
     hr.divider
       p
         ' Last seen


### PR DESCRIPTION
- Added links on the /users/{ID} and /users/{ID}/summary page to the edit and detail page for the user for admin users.
- Hid icons found in carousels from screenreaders.
- Cleanup of CSS for group css for icons.
- Cleanup of classes for notebook actions modal slim file.
- Changed color of warning icon for change requests page for all themes.
- On larger-text/font mode, made the search icon on home page, better aligned.
 