### PR TITLE
Home page/Notebook Listing id fixes and screenreader text injections on a few icons

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -971,7 +971,7 @@ body.page-revisions-id .alert.revision-page-alert {
 }
 
 /* ===== Notebook Tables ===== */
-#nbTable {
+.nb-table {
     border: 1px solid #e2e2e2;
     border-top: 0;
     width: 100%;
@@ -993,7 +993,7 @@ body.page-revisions-id .alert.revision-page-alert {
         margin: 2 0;
     }
 }
-#nbTable .title-wrapper {
+.nb-table .title-wrapper {
     clear: both;
     display: block;
     margin-top: .1em;
@@ -1030,25 +1030,25 @@ body.page-revisions-id .alert.revision-page-alert {
 .update-link {
     margin-left: .3em;
 }
-#nbTable #nb-description br,
-#nbTable .title-wrapper br   {
+.nb-table .nb-description br,
+.nb-table .title-wrapper br   {
     display: none;
 }
-#nbTable #nb-description {
+.nb-table .nb-description {
     text-align: left;
     p {
         white-space: pre-line;
         word-break: break-word;
     }
 }
-#nbTable .rankings-author-container {
+.nb-table .rankings-author-container {
     display: inline-block;
     text-align: left;
     .tags {
         display: inline-block;
     }
 }
-#nbTable .owner_footer {
+.nb-table .owner_footer {
     display: inline-block;
     font-family: $secondary-font-family;
     font-size: 14px;
@@ -1063,7 +1063,7 @@ body.page-revisions-id .alert.revision-page-alert {
         margin-left: 1em;
     }
 }
-#nbTable .tagRow {
+.nb-table .tagRow {
     &:hover {
         text-decoration: none;
     }
@@ -1074,7 +1074,7 @@ body.page-revisions-id .alert.revision-page-alert {
         margin: .15em .15em .5em;
     }
 }
-#nbTable .sparkline {
+.nb-table .sparkline {
     display: inline-block;
     margin: 0 .55em .2em .25em;
     position: relative;
@@ -1119,9 +1119,9 @@ body.page-revisions-id .alert.revision-page-alert {
         width: 32px;
     }
 }
-#nbTable {
+.nb-table {
     tr:hover hr,
-    #nbTable tr:nth-child(even) hr {
+    .nb-table tr:nth-child(even) hr {
         border-top: 1px solid #c0c0c0;
     }
     .comment {
@@ -1142,13 +1142,13 @@ body.page-revisions-id .alert.revision-page-alert {
         margin-right: 0;
     }
 }
-#nbTable,
+.nb-table,
 #notebookJumbo {
     .author-rep {
         margin: 0 3px 0 0;
     }
 }
-#nbStats {
+.nb-stats {
     .badge-notify {
         left: 0;
         top: 1px;
@@ -1162,7 +1162,7 @@ body.page-revisions-id .alert.revision-page-alert {
         font-size: 145%;
     }
 }
-#nbTable #snippetInfo {
+.nb-table .snippet-info {
     font-family: $secondary-font-family;
     font-size: 10pt;
     margin: .2em 0;
@@ -1183,7 +1183,7 @@ body.page-revisions-id .alert.revision-page-alert {
         margin-top: 6em;
     }
 }
-#nbTable .ribbon-wrapper {
+.nb-table .ribbon-wrapper {
     float: right;
     margin-top: -.1em;
     .github-fork-ribbon {
@@ -2962,7 +2962,7 @@ body.dark-theme {
     table.dataTable thead th.sorting {
         background: #bbb !important;
     }
-    #nbTable tr:nth-child(even),
+    .nb-table tr:nth-child(even),
     .dropdown-menu {
         background: $secondary-background;
     }
@@ -2971,22 +2971,22 @@ body.dark-theme {
         background: #c3c3c3;
         color: $text-color;
     }
-    #nbTable tr:nth-child(even),
+    .nb-table tr:nth-child(even),
     #searchTable tbody tr {
         background: $intermediate-icon-color;
     }
-    #nbTable tr:nth-child(odd),
+    .nb-table tr:nth-child(odd),
     #searchTable th,
     #notebookJumbo.info {
         background: #111;
     }
-    #nbTable tr:nth-child(odd),
-    #nbTable tr:nth-child(even) {
+    .nb-table tr:nth-child(odd),
+    .nb-table tr:nth-child(even) {
         .tags span.glyphicon,
-        #nb-description,
+        .nb-description,
         a.title,
         .owner_footer,
-        #snippetInfo,
+        .snippet-info,
         .badge  {
             color: $secondary-background;
         }
@@ -3064,7 +3064,7 @@ body.ultra-dark-theme {
     .super-container {
         filter: invert(100%)saturate(200%)contrast(120%);
     }
-    #nbTable a {
+    .nb-table a {
         color: $primary-link-color-darker;
     }
     .logo-link .logo-nb {
@@ -3142,7 +3142,7 @@ body.larger-text-mode {
     &.page-user_preferences select {
         height: 40px;
     }
-    #nbTable {
+    .nb-table {
         .title-wrapper .title {
             font-size :180%;
         }
@@ -3153,7 +3153,7 @@ body.larger-text-mode {
             font-size: 100%;
         }
         .owner_footer,
-        #snippetInfo {
+        .snippet-info {
             font-size: 110%;
         }
     }

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,6 @@
 # Static pages controller
 class StaticPagesController < ApplicationController
+  @@home_id = ""
   def home
     cookies[:home_viewed] = { value: Time.current.to_i, expires: 1.year.from_now }
   end
@@ -23,25 +24,20 @@ class StaticPagesController < ApplicationController
 
   # Homepage Layout
   def home_notebooks
-    # Recommendation list for the user
+    # Recommended Notebooks
     if (params[:type] == 'suggested' or params[:type].nil?) and @user.member?
       @notebooks = @user.notebook_recommendations.order('score DESC').first(Notebook.per_page)
-      locals = { ref: 'suggested' }
-    # List of all notebooks
+      @@home_id = 'suggested'
+    # All Notebooks
     elsif params[:type] == 'all' or params[:type].nil?
       @notebooks = query_notebooks
-      locals = { ref: 'all' }
-    # Recent
+      @@home_id = 'all'
+    # Recent Notebooks
     elsif params[:type] == 'recent'
       @sort = :created_at
       @notebooks = query_notebooks
-      locals = { ref: 'home_recent' }
-    # Newsfeed
-    #elsif params[:type] == 'updated'
-      #@sort = :updated_at
-      #@notebooks = query_notebooks
-      #locals = { ref: 'updated' }
-    # User's notebooks
+      @@home_id = 'home_recent'
+    # User's Notebooks
     elsif params[:type] == 'mine' and @user.member?
       @sort = :updated_at
       @notebooks = query_notebooks.where(
@@ -50,14 +46,22 @@ class StaticPagesController < ApplicationController
         @user.id,
         @user.id
       )
-      locals = { ref: 'home_updated' }
-    # Starred notebooks
+      @@home_id = 'home_updated'
+    # Starred Notebooks
     elsif params[:type] == 'stars'
       @notebooks = query_notebooks.where(id: @user.stars.pluck(:id))
-      locals = { ref: 'stars' }
+      @@home_id = 'stars'
     end
+    locals = { ref: @@home_id }
+    @@home_id = @@home_id.gsub("_"," ").split.map(&:capitalize).join('')
+    @@home_id[0] = @@home_id[0].downcase
     render layout: false, locals: locals
   end
+
+  def setup_home
+    return @@home_id
+  end
+  helper_method :setup_home
 
   def beta_notebook
     if params[:type] == 'learning'

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -58,10 +58,10 @@ class StaticPagesController < ApplicationController
     render layout: false, locals: locals
   end
 
-  def setup_home
+  def setup_home_id
     return @@home_id
   end
-  helper_method :setup_home
+  helper_method :setup_home_id
 
   def beta_notebook
     if params[:type] == 'learning'

--- a/app/views/application/_nb_stats.slim
+++ b/app/views/application/_nb_stats.slim
@@ -1,4 +1,4 @@
-div.tags.mouseoveredit id="nbStats"
+div.nb-stats.tags.mouseoveredit
   ==render partial: "notebook_metadata_metrics", locals: { notebook: notebook }
   -if defined? group_view
     ==link_to "",

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -1,4 +1,4 @@
-table.content.nb-table.table-responsive id="#{setup_home + 'NotebookListingTable'}" role="presentation"
+table.content.nb-table.table-responsive id="#{setup_home_id + 'NotebookListingTable'}" role="presentation"
   caption.sr-only Notebook Listings
   thead.sr-only
     tr

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -1,4 +1,4 @@
-table.content.table-responsive id="nbTable" role="presentation"
+table.content.nb-table.table-responsive id="#{setup_home + 'NotebookListingTable'}" role="presentation"
   caption.sr-only Notebook Listings
   thead.sr-only
     tr
@@ -83,7 +83,7 @@ table.content.table-responsive id="nbTable" role="presentation"
               -unless nb.snippet(@user).blank?
                 span.sr-only
                   ' Snippet Info:
-                div id="snippetInfo" ==nb.snippet(@user)
+                div.snippet-info ==nb.snippet(@user)
             div.tagRow
               -nb.tags.first(10).each do |tag|
                 a href="/tags/#{tag.tag}"

--- a/app/views/application/_table_nb_description.slim
+++ b/app/views/application/_table_nb_description.slim
@@ -1,4 +1,4 @@
-div.comment.more id ="nb-description"
+div.nb-description.comment.more
   -if nb.description.length > 500
     p.minimize.tooltip-right title="#{nb.description}"
       span.sr-only Description of Notebook

--- a/app/views/application/_tags_view.slim
+++ b/app/views/application/_tags_view.slim
@@ -11,8 +11,8 @@ div.tags.mouseoveredit id="tagsDisplay"
           ==tag.tag
           span.sr-only #{"\""}
       span.hidden aria-hidden="true" #{" "}
-    a.glyphicon.glyphicon-pencil.tooltips.edit-icon href="#" id="tagsEditPencil" title="Add or edit tags"
-      span.sr-only #{" "}
+    a.edit-icon href="#" id="tagsEditPencil"
+      span.glyphicon.glyphicon-pencil.tooltips aria-hidden="true" title="Add or edit tags"
       span.sr-only
         -if notebook.tags.count > 0
           | Edit tags

--- a/app/views/environments/index.slim
+++ b/app/views/environments/index.slim
@@ -51,14 +51,15 @@ div.content-container
         tr
           -if environment.default
             td
-              i.fa.fa-check aria-hidden="false" aria-label="Checkmark denotes that given row represents your default Jupyter environment"
+              i.fa.fa-check aria-hidden="false"
+              span.sr-only Default Jupyter environment
           -else
             td
-              i aria-label="Row is not set as your default Jupyter Environment"
-          td =environment.name
-          td =environment.url
+              span.sr-only Row is not set as default Jupyter environment
+          td ==environment.name
+          td ==environment.url
           td
-            time.tooltips.tooltip-right.tooltipstered title="#{environment.updated_at.strftime("%A, %B %d, %Y %H:%M UTC")}"
+            time.tooltips.tooltip-right.tooltipstered title="#{environment.updated_at.strftime('%A, %B %d, %Y %H:%M UTC')}"
               |  #{time_ago_in_words(environment.updated_at)} ago
           td
             a.editEnvironment.modal-activate href="#" data-environmentName="#{environment.name}"

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -212,8 +212,8 @@ div.content-container
           ==@notebook.description
       -if @user.can_edit?(@notebook) || @user.admin?
         a.edit-icon id="editDescription" href="#"
-          span.glyphicon.glyphicon-pencil.tooltips title="Edit description"
-            span.sr-only Edit description
+          span.glyphicon.glyphicon-pencil.tooltips title="Edit description" aria-hidden="true"
+          span.sr-only Edit description
     form id="descriptionEditForm" enctype="multipart/form-data" role="form" style="display: none"
       div.input-group data-toggle="tooltip" title="Edit description here"
         textarea id="descriptionField" ==@notebook.description

--- a/app/views/notebooks/_notebook_jumbotron_title.slim
+++ b/app/views/notebooks/_notebook_jumbotron_title.slim
@@ -25,6 +25,6 @@ div id="titleView"
     -if @user.can_edit?(@notebook) || @user.admin?
       span.sr-only #{" "}
       a.edit-title href="#" id="editTitleButton"
-        span.glyphicon.glyphicon-pencil.tooltips title="Edit title"
+        span.glyphicon.glyphicon-pencil.tooltips aria-hidden="true" title="Edit title"
         span.sr-only Edit title
     span.error.hidden id="titleError"


### PR DESCRIPTION
- Added IDs to home page tab listings for better targeting
- Removed IDs in notebook listings where they clearly shouldn't have been as numerous elements were existing simultaneously with the same ID.
- Added some screenreader-only text to the environments page and notebook jumbrotron page
    - In addition made adjustments to the tag edit icon under the hood to follow the same coding and html as the other two edit icons (edit title and edit description.

Has been tested and all changes have been done through global find/replace so nothing is using the old spelling or ID of these notebook listings.