### PR TITLE
Group visibility changes

### DIFF
--- a/app/views/groups/index.slim
+++ b/app/views/groups/index.slim
@@ -20,4 +20,6 @@ div.content-container
   -if @user.groups.count - @groups.length > 0
     div class="alert alert-info content-body-alert"
         i.fa.fa-info-circle aria-hidden="true"
-        | Not revealing #{@user.groups.count - @groups.length} of your groups because they aren't owners of any notebooks.
+        ' Not revealing #{@user.groups.count - @groups.length} of your groups because they aren't owners of any notebooks. Go to
+        a href="#{groups_user_path(@user)}" My Groups
+        |  to see what groups weren't included.

--- a/app/views/users/groups.slim
+++ b/app/views/users/groups.slim
@@ -5,7 +5,8 @@ div.content-container
   a.dropdownGroup.modal-activate id="newGroupButton" href="#" data-target="#newGroup" data-toggle="modal" tabindex="-1"
     button.btn.btn-primary.createGroup Create Group
   ul.list-group
-    -sorted_group_array = @groups.sort {|a,b| b[1] <=> a[1] }
+    -groups = Group.where(id: (GroupMembership.where(user_id: @user.id).pluck(:group_id)))
+    -sorted_group_array = groups.sort {|a,b| b.notebooks.count <=> a.notebooks.count }
     -sorted_group_array.each do |group, count|
       li.list-group-item.groupSearchResults
         a href="#{url_for(group)}"
@@ -19,7 +20,3 @@ div.content-container
           -else
             span.sr-only #{" notebooks"}
           span.hidden aria-hidden="true" #{")"}
-  -if @user.groups.count - @groups.length > 0
-    div class="alert alert-info content-body-alert"
-        i.fa.fa-info-circle aria-hidden="true"
-        | Not revealing #{@user.groups.count - @groups.length} groups because they aren't owners of any notebooks.

--- a/app/views/users/groups.slim
+++ b/app/views/users/groups.slim
@@ -5,7 +5,8 @@ div.content-container
   a.dropdownGroup.modal-activate id="newGroupButton" href="#" data-target="#newGroup" data-toggle="modal" tabindex="-1"
     button.btn.btn-primary.createGroup Create Group
   ul.list-group
-    -@groups.each do |group, _count|
+    -sorted_group_array = @groups.sort {|a,b| b[1] <=> a[1] }
+    -sorted_group_array.each do |group, count|
       li.list-group-item.groupSearchResults
         a href="#{url_for(group)}"
           span.tooltips.multiple title="#{group.description.nil? || group.description == '' ? '(no description)' : group.description}" #{group.name}


### PR DESCRIPTION
- Revealed all groups on user's groups page
- Sorted results on User's groups page by number of owned notebook so it matches the functionality of the /groups page
- Updated the /groups page to include a link to the User's group page if users want to see all of the groups of theirs not included because they contain no notebooks within them