### PR TITLE
User-Pagination: Made it so the users page paginates if you have more than 100 users

### DIFF
--- a/app/views/users/index.slim
+++ b/app/views/users/index.slim
@@ -13,7 +13,8 @@ div.content-container
         th colspan="4" Actions
 
     tbody
-      -@users.each do |user|
+      -users = @users.order(:user_name).paginate(page: @page, per_page: 100)
+      -users.each do |user|
         tr
           td ==user.user_name
           td ==user.first_name
@@ -32,3 +33,6 @@ div.content-container
               i.glyphicon.glyphicon-trash.tooltips title='Destroy this user'
               span.sr-only Destroy
   br
+  -if users.respond_to? :total_pages
+    nav.center
+      ==will_paginate users, renderer: BootstrapPagination::Rails


### PR DESCRIPTION
Tested result with 3 and 100 objects per pagination.. Screenshots below are what it looks like when we paginate after 3.

NOTE - didn't add any filtering abilities, just sorted it by username (instead of id which is how it was done before)

![users page 1](https://user-images.githubusercontent.com/51969207/73478924-eec68680-4364-11ea-8ec0-33d98abfbf2b.PNG)

![users page 2](https://user-images.githubusercontent.com/51969207/73478930-f25a0d80-4364-11ea-8d1a-3a157ba083bc.PNG)