### PR TITLE
Hotfix-1: Fixed the issue where non-home page notebook listings were returning an error

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,6 @@
 # Static pages controller
 class StaticPagesController < ApplicationController
-  @@home_id = ""
+
   def home
     cookies[:home_viewed] = { value: Time.current.to_i, expires: 1.year.from_now }
   end
@@ -21,47 +21,6 @@ class StaticPagesController < ApplicationController
   def beta_home_notebooks
     home_notebooks
   end
-
-  # Homepage Layout
-  def home_notebooks
-    # Recommended Notebooks
-    if (params[:type] == 'suggested' or params[:type].nil?) and @user.member?
-      @notebooks = @user.notebook_recommendations.order('score DESC').first(Notebook.per_page)
-      @@home_id = 'suggested'
-    # All Notebooks
-    elsif params[:type] == 'all' or params[:type].nil?
-      @notebooks = query_notebooks
-      @@home_id = 'all'
-    # Recent Notebooks
-    elsif params[:type] == 'recent'
-      @sort = :created_at
-      @notebooks = query_notebooks
-      @@home_id = 'home_recent'
-    # User's Notebooks
-    elsif params[:type] == 'mine' and @user.member?
-      @sort = :updated_at
-      @notebooks = query_notebooks.where(
-        "(owner_type='User' AND owner_id=?) OR (creator_id=?) OR (updater_id=?)",
-        @user.id,
-        @user.id,
-        @user.id
-      )
-      @@home_id = 'home_updated'
-    # Starred Notebooks
-    elsif params[:type] == 'stars'
-      @notebooks = query_notebooks.where(id: @user.stars.pluck(:id))
-      @@home_id = 'stars'
-    end
-    locals = { ref: @@home_id }
-    @@home_id = @@home_id.gsub("_"," ").split.map(&:capitalize).join('')
-    @@home_id[0] = @@home_id[0].downcase
-    render layout: false, locals: locals
-  end
-
-  def setup_home_id
-    return @@home_id
-  end
-  helper_method :setup_home_id
 
   def beta_notebook
     if params[:type] == 'learning'

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -1,4 +1,9 @@
-table.content.nb-table.table-responsive id="#{setup_home_id + 'NotebookListingTable'}" role="presentation"
+-url_check = request.path.split("/")
+-if url_check[1] == "notebooks" && params[:q] != nil && params[:q].length > 0
+  -table_id = "search"
+-else
+  -table_id = setup_home_id
+table.content.nb-table.table-responsive id="#{table_id + 'NotebookListingTable'}" role="presentation"
   caption.sr-only Notebook Listings
   thead.sr-only
     tr


### PR DESCRIPTION
- Moved the home page tab table generation method to the main application controller (pretty much only change)
- Added id to table for notebook listings generated by a search

Tested home page tabs, searches, and all pages that generate notebook listings (all look good now)