### PR TITLE
Header-Search-on-mobile: Made it autofocus when activated

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -138,6 +138,7 @@ document.addEventListener("turbolinks:load", function(){
     $('#expandableSearchDropdown').toggleClass('focus-back');
     if($(this).hasClass('focus-back')){
       $('#expandableSearchDropdown').css("display","block");
+      $('#expandableSearchDropdown .searchFieldBox').focus();
     }
     else {
       $('#expandableSearchDropdown').css("display","none");


### PR DESCRIPTION
When clicking on the expandable search icon on mobile/magnified zoom, the cursor will automatically pop up in the input field for the search so you can just begin immediately typing.

![expandable search auto focuses](https://user-images.githubusercontent.com/51969207/73760877-fce91e00-473b-11ea-8af6-10cf7d5bb22f.PNG)
