### PR TITLE
Cron schedules in config and ability to disable sunpot in dev

### DIFF
--- a/config/cronic.d/jobs.rb
+++ b/config/cronic.d/jobs.rb
@@ -4,39 +4,33 @@ self.in '1s' do
 end
 
 # Age off
-# Run at 1215am daily
-cron '15 0 * * * UTC' do
+cron GalleryConfig.cron.age_off do
   ScheduledJobs.run(:age_off)
 end
 
 # Notebook daily summaries
-# Run at 1230am daily
-cron '30 0 * * * UTC' do
+cron GalleryConfig.cron.notebook_dailies do
   ScheduledJobs.run(:notebook_dailies)
 end
 
 # User click summaries
-# Run at 1235am daily
-cron '35 0 * * * UTC' do
+cron GalleryConfig.cron.user_summaries do
   ScheduledJobs.run(:user_summaries)
 end
 
 # Notebook click summaries
-# Run at 0100am daily
-cron '0 1 * * * UTC' do
+cron GalleryConfig.cron.notebook_summaries do
   ScheduledJobs.run(:notebook_summaries)
 end
 
 # Subscription email
-# Run at 0800am Monday-Friday
-cron '0 8 * * 1-5 UTC' do
+cron GalleryConfig.cron.daily_subscription_email do
     ScheduledJobs.run(:daily_subscription_email)
 end
 
 # Notebook suggestions
 if Rails.env.production?
-  # Run at 0400am daily
-  cron '0 4 * * * UTC' do
+  cron GalleryConfig.cron.nightly_computation do
     ScheduledJobs.run(:nightly_computation)
   end
 else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.raise_delivery_errors = true
+
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
   if ENV['EMAIL_SERVER'].present?
     config.action_mailer.delivery_method = :smtp
@@ -27,6 +27,11 @@ Rails.application.configure do
       authentication: :login
     }
   end
+
+  # Run embedded solr.
+  # Set this to false if you're running your own solr instance in dev
+  config.run_solr = true
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
 

--- a/config/initializers/sunspot.rb
+++ b/config/initializers/sunspot.rb
@@ -1,6 +1,6 @@
 require 'rake'
 
-if defined?(Rails::Server) && Rails.env.development?
+if defined?(Rails::Server) && Rails.env.development? && Rails.configuration.run_solr
   Rails.application.load_tasks
 
   Rake.application.invoke_task 'sunspot:solr:start'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -42,6 +42,15 @@ storage:
 scheduler:
   internal: true
 
+# cron schedules
+cron:
+  age_off: 15 0 * * * UTC # 1215am daily
+  notebook_dailies: 30 0 * * * UTC # 1230am daily
+  user_summaries: 35 0 * * * UTC # 1235am daily
+  notebook_summaries: 0 1 * * * UTC # 0100am daily
+  daily_subscription_email: 0 8 * * 1-5 UTC # 0800am Monday-Friday
+  nightly_computation: 0 4 * * * UTC # 0400am daily
+
 # Notebook review options
 reviews:
   technical:

--- a/docs/scheduled_jobs.md
+++ b/docs/scheduled_jobs.md
@@ -16,7 +16,7 @@ The main jobs are defined in [scheduled_jobs.rb](../lib/scheduled_jobs.rb), and 
    * recommendations: find notebooks, groups, tags that are most relevant to each user.
    * reviews: computations for the [notebook peer review system](notebook_review.md).
    * wordclouds: word cloud image maps for each notebook plus one for the overall corpus.
-   
+
 ## How to run jobs
 
 By default, the app will run an internal scheduler thread using the [default schedule](../config/cronic.d/jobs.rb).  Depending on what Rack server you use, this may be bad.  For example, the way Passenger spins up extra processes/threads and shuts them down can lead to the scheduler thread dying and not restarting.  For that type of environment, you can use the [cronic script](../script/cronic) to run the jobs in a separate process outside the app.  See the [startup/shutdown notes](running.md) for example commands.
@@ -26,3 +26,5 @@ If you don't like the default schedule, or if you'd prefer to use standard `cron
 ```
 bundle exec rails runner script/run_job.rb age_off
 ```
+
+Alternatively, you may also configure the cron schedules by changing the cron values in [settings.yml](../config/settings.yml).


### PR DESCRIPTION
Cron schedules are defined in config instead of being hard coded. Added ability to enable / disable sunpot in development environment