### PR TITLE
Ui changes

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -149,8 +149,16 @@ document.addEventListener("turbolinks:load", function(){
       data: {description:data},
       success: function() {
         location.reload();
+      },
+      error: function(response) {
+        if (response.responseJSON.message && response.responseJSON.message.length > 0) {
+          bootbox.alert('Error: ' + response.responseJSON.message);
+        } else{
+          bootbox.alert('Error: ' + response.responseText);
+        }
       }
     });
+    return false;
   });
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -62,7 +62,7 @@
 }
 .notebookModals {
     margin: auto;
-    padding-top: 100px;
+    margin-top: 100px;
     width: 75%;
 }
 .homepageModal {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -170,12 +170,11 @@ class GroupsController < ApplicationController
       editor = %i[creator owner editor].include?(role)
 
       gm = @group.membership.where(user: user).first
-      if gm
-        # Existing user - update privileges
-        gm.owner = owner
-        gm.editor = editor
-      else
-        # New user
+      update = gm&.owner != owner || gm&.editor != editor
+      if !gm || update
+        # Existing user - remove old membership before re-adding
+        @group.users -= [user] if update
+
         @group.membership << GroupMembership.new(
           user: user,
           group: @group,

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -66,6 +66,9 @@ class NotebooksController < ApplicationController
   # Must accept terms when uploading/updating @notebook
   before_action :verify_accepted_terms, only: %i[create update]
 
+  # Check if non admins can submit reviews
+  before_action :verify_admin, only: :submit_for_review,
+    unless: ->  { GalleryConfig.user_permissions.propose_review }
 
   #########################################################
   # Primary member endpoints
@@ -417,14 +420,9 @@ class NotebooksController < ApplicationController
   # PATCH /notebooks/:uuid/description
   def description=
     @notebook.description = (params[:description] || '').strip
-    if @notebook.description != ''
-      @notebook.save!
-      render json: { description: @notebook.description }
-      flash[:success] = "Notebook description has been updated successfully."
-    else
-      flash[:error] = "Notebook description has failed to update. Descriptions cannot be empty."
-      redirect_to(:back)
-    end
+    @notebook.save!
+    render json: { description: @notebook.description }
+    flash[:success] = "Notebook description has been updated successfully."
   end
 
   # GET /notebooks/:uuid/uuid

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -30,6 +30,14 @@ class RevisionsController < ApplicationController
     @diff = GalleryLib::Diff.split(before, after)
   end
 
+  # GET /notebooks/:notebook_id/revisions/:commit_id/metadata
+  def metadata
+    meta = {}
+    meta[:git_commit_id] = @revision.commit_id
+    meta[:title] = "#{@notebook.title} - Rev #{@revision.commit_id.first(8)}"
+    render json: meta
+  end
+
   # GET /notebooks/:notebook_id/revisions/latest_diff
   def latest_diff
     revs = @revisions.reject {|r| r.revtype == 'metadata'}

--- a/app/models/jupyter_notebook.rb
+++ b/app/models/jupyter_notebook.rb
@@ -110,6 +110,7 @@ class JupyterNotebook
       cell['execution_count'] = nil
       cell['metadata']&.delete('ExecuteTime')
     end
+    JupyterNotebook.custom_strip_output(self)
     self
   end
 
@@ -248,6 +249,10 @@ class JupyterNotebook
       end
     end
     proposed
+  end
+
+  # Allows custom stripping of data from notebook
+  def self.custom_strip_output(jn)
   end
 
   # Call validate_ methods defined by extensions

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -499,15 +499,18 @@ class Notebook < ActiveRecord::Base
 
   # List of revisions that the user can see
   def revision_list(user, options={})
-    # Only return revisions back until the most recent one the user can't see.
+    # Only return revisions back until the most recent one the user can't see
+    # unless stop_at_private is set to false.
     # For example if the nb was public then private then public, the user can't
-    # see revisions from the first public time period, only the recent period.
+    # see revisions from the first public time period, only the recent period,
+    # unless stop_at_private option is set to false.
     use_admin = options[:use_admin] || false
     max = options[:max]
     exclude_metadata = options[:exclude_metadata] || false
+    stop_at_private = options[:stop_at_private] || true
     allowed = []
     revisions.order(created_at: :desc).each do |rev|
-      break unless user.can_read_revision?(rev, use_admin)
+      break unless !stop_at_private || user.can_read_revision?(rev, use_admin)
       allowed << rev unless exclude_metadata && rev.revtype == 'metadata'
       break if max && allowed.count >= max
     end

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -253,7 +253,7 @@ div.modal.fade id="showNotebookUUIDModal" aria-labelledby="showNotebookUUIDHeade
               span.sr-only
                 |  Dialog
 
--if @user.admin?
+-if @user.admin? || (GalleryConfig.user_permissions.propose_review && @user.can_edit?(@notebook, true))
   div.modal.fade id="proposeReviewModal" aria-labelledby="proposeReviewHeader" aria-describedby="proposeReviewDescription" role="dialog" style="display: none" tabindex="0"
     div.modal-dialog
       div.modal-content

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -120,7 +120,7 @@ div.content-container
                   a.modal-activate href="#editNotebookModal" id="editNotebook" data-toggle="modal"
                     span.gear-dropdown-icon.glyphicon.glyphicon-upload aria-hidden="true"
                     | Upload new version
-                -if GalleryConfig.user_permissions.propose_review
+                -if GalleryConfig.user_permissions.propose_review && !@user.admin?
                   li
                     a.modal-activate href="#proposeReviewModal" id="userProposeReview" data-toggle="modal"
                       span.gear-dropdown-icon.fa.fa-file-code-o aria-hidden="true"
@@ -131,7 +131,7 @@ div.content-container
                     | Delete notebook
                     span id="deleteConfirm"
                     span id="deleteWaiting"
-              -if !GalleryConfig.user_permissions.propose_review && @user.admin?
+              -if @user.admin?
                 li.divider
                 li.dropdown-header.filter-item Admin Actions
                 li

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -120,13 +120,18 @@ div.content-container
                   a.modal-activate href="#editNotebookModal" id="editNotebook" data-toggle="modal"
                     span.gear-dropdown-icon.glyphicon.glyphicon-upload aria-hidden="true"
                     | Upload new version
+                -if GalleryConfig.user_permissions.propose_review
+                  li
+                    a.modal-activate href="#proposeReviewModal" id="userProposeReview" data-toggle="modal"
+                      span.gear-dropdown-icon.fa.fa-file-code-o aria-hidden="true"
+                      | Propose for Review
                 li
                   a href="#" id="deleteNotebook"
                     span.gear-dropdown-icon.glyphicon.glyphicon-trash aria-hidden="true"
                     | Delete notebook
                     span id="deleteConfirm"
                     span id="deleteWaiting"
-              -if @user.admin?
+              -if !GalleryConfig.user_permissions.propose_review && @user.admin?
                 li.divider
                 li.dropdown-header.filter-item Admin Actions
                 li

--- a/app/views/notebooks/_notebook_jumbotron_title.slim
+++ b/app/views/notebooks/_notebook_jumbotron_title.slim
@@ -24,6 +24,16 @@ div id="titleView"
           span.sr-only ==review_status_string(@notebook)
         span.hidden aria-hidden="true" #{"]"}
         span.sr-only #{" "}
+      -else
+        -revision = fully_reviewed_prior_revision(@notebook, @user)
+        -if revision
+          span.sr-only #{" "}
+          span.hidden aria-hidden="true" #{"["}
+          a.nounderline href="#{reviews_notebook_path(@notebook)}"
+            ==image_tag("verified-badge-grayed.png", class: "tooltips verified-icon", title: prior_revision_review_status_string(revision))
+            span.sr-only ==review_status_string(@notebook)
+          span.hidden aria-hidden="true" #{"]"}
+          span.sr-only #{" "}
     -url_check = request.path.split("/")
     -if url_check[3] == "revisions"
       span.revision-version ==@revision.commit_id.first(8)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Rails.application.routes.draw do # rubocop: disable Metrics/BlockLength
       member do
         get 'download'
         get 'diff'
+        get 'metadata'
       end
       collection do
         get 'latest_diff'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,6 +54,9 @@ reviews:
     enabled: false
     label: compliance
 
+user_permissions:
+  propose_review: false
+
 # Email options
 email:
   general_from:


### PR DESCRIPTION
A few changes in this pull request:
- Ability to allow users to propose their own reviews - can be enabled / disabled by config value. By default, it is disabled
- Show gray badge when a previous revision of a notebook has been fully reviewed (and the current revision hasn't)
- Ability to customize stripping of notebook data in extensions
- Metadata endpoint for revisions
- A few bug fixes: users couldn't change group membership, no error was shown if the editing of notebook descriptions failed and CSS padding on modals fix