### PR TITLE
Added Return link for Code Cells & did cleanup for others

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2287,9 +2287,6 @@ body.page-metrics .panel-heading {
         border-radius: 3px;
     }
 }
-button#metricsViewNotebook {
-    margin-bottom: 12px;
-}
 .panel.panel-heading {
     border-radius: 0;
     margin-bottom: 0;
@@ -2442,10 +2439,6 @@ body.page-summary h1 #userDetailLink i {
 }
 body.page-summary .author-rep {
     font-size: 18px;
-}
-body.path-users-id-summary .return {
-    float: none;
-    margin: 2em 0 -1em;
 }
 .user-summary .glyphicon {
     margin-right: 5px;
@@ -2826,12 +2819,23 @@ body.page-change_requests-id .ribbon-wrapper {
     }
 }
 .return {
-    float: left;
     font-size: 120%;
     margin: 1em 0 .5em;
     i.fa.fa-share {
         margin-right: .2em;
         transform: scaleX(-1);
+    }
+    body.path-users-id-summary & {
+        margin: 2em 0 -1em;
+    }
+    body.page-change_requests-id & {
+        float: left;
+    }
+    body.path-notebooks-id-metrics &,
+    body.page-code_cells-id & {
+        font-size: 150%;
+        margin-bottom: 12px;
+        text-align: center;
     }
 }
 body.page-change_requests-id .btn .caret {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2834,8 +2834,10 @@ body.page-change_requests-id .ribbon-wrapper {
     body.path-notebooks-id-metrics &,
     body.page-code_cells-id & {
         font-size: 150%;
-        margin-bottom: 12px;
         text-align: center;
+    }
+    body.path-notebooks-id-metrics & {
+        margin-bottom: .75em;
     }
 }
 body.page-change_requests-id .btn .caret {

--- a/app/views/change_requests/show.slim
+++ b/app/views/change_requests/show.slim
@@ -136,7 +136,7 @@ javascript:
 ==csrf_meta_tag
 div.content-container
   div.return
-    a.tooltips href="#{change_requests_path}" title="Go to Change Requests page" aria-label="Go to change requests page"
+    a href="#{change_requests_path}"
       i.fa.fa-share aria-hidden="true"
       | See all your change requests
   h1.center

--- a/app/views/code_cells/show.slim
+++ b/app/views/code_cells/show.slim
@@ -1,5 +1,9 @@
 ==render partial: 'notebooks/notebook_info_jumbotron'
 div.content-container
+  div.return
+    a href="#{notebook_path(@notebook)}"
+      i.fa.fa-share aria-hidden="true"
+      | Return to Notebook
   h2.cell-count Code Cell #{@code_cell.cell_number + 1} / #{@notebook.code_cells.count}
   div.code-cell-nav
     -if @code_cell.cell_number > 0

--- a/app/views/notebooks/notebook_metrics.slim
+++ b/app/views/notebooks/notebook_metrics.slim
@@ -10,10 +10,10 @@ javascript:
 
 ==render partial: "notebook_info_jumbotron"
 div.content-container
-  div.row
-    div.col-md-12.center
-      a href="#{notebook_path(@notebook)}"
-        button.btn.btn-primary.center id="metricsViewNotebook" tabindex="-1" View Notebook
+  div.return
+    a href="#{notebook_path(@notebook)}"
+      i.fa.fa-share aria-hidden="true"
+      | Return to Notebook
   div.pop-ups.row
     div.col-lg-3.col-md-6
       div.panel.panel-primary


### PR DESCRIPTION
Added return link for code cells and made the rest more consistent with one another. Also removed redundant accessibility labels.

![code cells](https://user-images.githubusercontent.com/51969207/76125808-9c176480-5fcb-11ea-8b61-af678d3df81d.PNG)

![metrics return](https://user-images.githubusercontent.com/51969207/76125810-9e79be80-5fcb-11ea-99e3-5c5850da5e11.PNG)

![user summary return](https://user-images.githubusercontent.com/51969207/76125817-a0dc1880-5fcb-11ea-9961-6c0a298ee818.PNG)

![change request](https://user-images.githubusercontent.com/51969207/76125818-a0dc1880-5fcb-11ea-8ebe-40e060d122c5.PNG)
