### PR TITLE
Add Gallery_url to Notebook metadata when sending to Jupyter

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -247,6 +247,7 @@ class NotebooksController < ApplicationController
       gallery.delete('link')
     end
     gallery['commit'] = @notebook.commit_id
+    gallery['gallery_url'] = request.base_url
     revision = @notebook.revisions.last
     gallery['git_commit_id'] = revision.commit_id if revision
 


### PR DESCRIPTION
I am just using the base_url at this time because that ensures it caputres the URL it actually came from for easiest flexibility. I am open to other ideas on this though.