### PR TITLE
Added a useful message to empty groups if the user viewing the empty …

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -772,6 +772,10 @@ span.review-alert {
 .alert h5 {
     margin: .4em 0;
 }
+.alert ol,
+.alert ul {
+    margin: 5px 0 5px 15px;
+}
 .alert .close {
     box-shadow: none;
     opacity: .7;
@@ -2139,6 +2143,9 @@ body.page-notebooks-learning .carousel-caption h1 {
         margin-bottom: .5rem;
         margin-top: -15px;
     }
+}
+body.page-groups-id h2.empty {
+    margin: 1em 0;
 }
 
 /* ===== Search Pages ===== */

--- a/app/views/groups/show.slim
+++ b/app/views/groups/show.slim
@@ -52,11 +52,16 @@ div.content-container.mobile-expanding
               |  to make that notebook the landing page.
 
 -if @notebooks.empty?
-  div.content-container.center
-    div.no-notebooks
-      div.sad-face.show aria-hidden="true" style="display: none"
-        | :-(
-      | Sorry, no notebooks found
+  div.content-container
+    h2.center
+      | No Notebooks Found
+    -if @user.group_editor?(@group)
+      p
+        | To add a notebooks to this group:
+        ul
+          li Upload a new notebook or visit a notebook that you own
+          li Click the gear and select "Change Ownership"
+          li Search for and choose this group as the new owner
 -else
   -unless @landing.nil?
     div.content-container id="groupLanding"

--- a/app/views/groups/show.slim
+++ b/app/views/groups/show.slim
@@ -53,15 +53,16 @@ div.content-container.mobile-expanding
 
 -if @notebooks.empty?
   div.content-container
-    h2.center
-      | No Notebooks Found
+    h2.center.empty No Notebooks Found
     -if @user.group_editor?(@group)
-      p
-        | To add a notebooks to this group:
-        ul
-          li Upload a new notebook or visit a notebook that you own
-          li Click the gear and select "Change Ownership"
-          li Search for and choose this group as the new owner
+      div.alert.alert-info.modal-alert
+        i.fa.fa-info-circle aria-hidden="true"
+        span To add a notebooks to this group
+        span aria-hidden="true" #{":"}
+        ol
+          li Upload a new notebook or visit a notebook that you own.
+          li Click the gear and select "Change Ownership".
+          li Search for and choose this group as the new owner.
 -else
   -unless @landing.nil?
     div.content-container id="groupLanding"


### PR DESCRIPTION
…group is a group editor

provides instructions for how to assign notebooks to groups
Groups that have notebooks but no langing page already have a helper in the group title area about making a landing page.

Closes #199

@manfromjupyter You can stylize it more if you would like.