### PR TITLE
Patch for same-site cookie header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source ENV['GALLERY_GEM_SOURCE'] || 'https://rubygems.org'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2'
 #gem 'sprockets', '3.6.0' # 3.6.1 breaks all javascript by saying there's a invalid byte sequence
@@ -54,6 +53,7 @@ gem 'rufus-scheduler'
 gem 'slim-rails'
 gem 'therubyracer'
 gem 'will_paginate-bootstrap'
+gem 'rails_same_site_cookie'
 
 # API clients
 gem 'httmultiparty'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source ENV['GALLERY_GEM_SOURCE'] || 'https://rubygems.org'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2'
 #gem 'sprockets', '3.6.0' # 3.6.1 breaks all javascript by saying there's a invalid byte sequence

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_same_site_cookie (0.1.8)
+      rack (>= 1.5)
+      user_agent_parser (~> 2.5)
     railties (4.2.11.3)
       actionpack (= 4.2.11.3)
       activesupport (= 4.2.11.3)
@@ -354,6 +357,7 @@ GEM
     uglifier (4.1.15)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.3)
+    user_agent_parser (2.5.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -414,6 +418,7 @@ DEPENDENCIES
   puma
   rack-cors
   rails (~> 4.2)
+  rails_same_site_cookie
   ranker
   redcarpet
   retriable


### PR DESCRIPTION
Samesite is not supported in the Rails 4 session manager
using rails_same_site_cookie to solve that.
Closes #276
Background information for same-site: https://www.chromium.org/updates/same-site
NOTE: Chrome only supports this over HTTPS