### PR TITLE
Toggling back and forth on group view notebooks no longer causes sparkline disappearance 

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -451,8 +451,12 @@ $(document).ready(function(){
       $('#groupToggle').click();
     }
   });
+  var viewToggled = false;
   $("#groupToggle").on("click", function(){
-    $('.sparkline').sparkline();
+    if(!viewToggled) {
+      $('.sparkline').sparkline();
+      viewToggled = true;
+    }
   });
 
   /* ===================================== */


### PR DESCRIPTION
Fixed issue #284 where toggling to notebook view on Group pages more than one time causes sparkline graphic to disappear 