### PR TITLE
Resource links

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -10,8 +10,8 @@ $(document).ready(function(){
       $('#mobileNavContainer').click();
     }
   });
-  $('#mobileNavContainer').click(function(event) {
-    event.preventDefault();
+  $('#mobileNavContainer').click(function(e) {
+    e.preventDefault();
     $(this).toggleClass('expand');
     $('#mobileNavDropdown').toggleClass('open');
     if($(this).hasClass('expand')){
@@ -191,8 +191,8 @@ $(document).ready(function(){
   $('#newHomePageNotebooks').load('/home_notebooks');
 
   // Loading opacity & spinner when tab is clicked or Enter key is pressed (508 compliance)
-  $('.page-home .tabLink').on("click", function(event){
-    event.preventDefault();
+  $('.page-home .tabLink').on("click", function(e){
+    e.preventDefault();
     $(document).ajaxStart(function(){
       if ($('#initialLoadImage').length < 1) {
         $("wait").css("display", "block");
@@ -484,8 +484,8 @@ $(document).ready(function(){
       $('#recommendationToggle').click();
     }
   });
-  $('#recommendationToggle').on('click', function(event){
-    event.preventDefault();
+  $('#recommendationToggle').on('click', function(e){
+    e.preventDefault();
     $(this).toggleClass('is-active');
     $('.jumbotron.notebookAddInfo').toggleClass('is-active');
     if ($('#recommendationToggle').hasClass('is-active')) {

--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -160,6 +160,36 @@ $(document).ready(function(){
     });
     return false;
   });
+
+  $('#add_external_resource').click(function(){
+    $('#addResourceModal').modal();
+  });
+  $('#addResourceForm').on('submit',function(){
+    $('#addResourceFormSubmit').attr('disabled', true);
+    var url = '/notebooks/' + id + '/resource';
+    var data = 'href=' + $('#newResourceHref').val() + "&title=" + $("#newResourceTitle").val();
+    bootboxPending('Adding Resource to Notebook');
+    $.ajax({
+      url: url,
+      data: data,
+      type: 'POST',
+      success: function() {
+        $('#addResourceModal').modal('hide');
+        bootbox.hideAll();
+        location.reload();
+      },
+      error: function(response) {
+        bootbox.hideAll();
+        $('#addResourceError').html('<strong>Error: </strong>' + response.responseText);
+        $('#addResourceError').attr('hidden',false);
+      },
+    });
+    return false;
+  });
+  $('#resourceDelete').click(function(){
+
+  });
+
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -161,7 +161,16 @@ $(document).ready(function(){
     return false;
   });
 
-  $('#add_external_resource').click(function(){
+  /* Add External Resource */
+  $('#add_external_resource').keypress(function(e){
+    var keycode = (e.keyCode ? event.keyCode : event.which);
+    if(keycode == '13' || keycode == '32'){
+      e.preventDefault();
+      $('#add_external_resource').click();
+    }
+  });
+  $('#add_external_resource').click(function(e){
+    e.preventDefault();
     $('#addResourceModal').modal();
   });
   $('#addResourceForm').on('submit',function(){
@@ -186,13 +195,6 @@ $(document).ready(function(){
     });
     return false;
   });
-  $('#resourceDelete').click(function(){
-
-  });
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
 
   // Determine if the user is clicking a change request or submitting new version and adjust the shared modals accordingly  ///////////
   $('#submitChangeRequest').on('click',function(){
@@ -201,8 +203,6 @@ $(document).ready(function(){
       $('#editTagsSection').hide();
       $('#stageChangeRequestComment').show();
   });
-  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
   // Part 1 of submit change request or upload new version - this is only applicable to the Gallery UI /////////////////////////////////
   $('#editNotebook').on('click',function(){
@@ -486,7 +486,6 @@ $(document).ready(function(){
               window.location=response.forward;
             },
             error: function(response){
-              console.log(response);
               bootbox.hideAll();
               bootbox.alert('You had an error! ' + response.statusText);
             }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1583,7 +1583,7 @@ form .edit-buttons {
 }
 #notebookJumbo .externalResources{
   .externalResourcesTitle {
-      font-weight: bold;
+      font-weight: $bold-weight;
   }
   a.delete-icon, a.add-icon{
     text-decoration: none;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1585,9 +1585,6 @@ form .edit-buttons {
     .externalResourcesTitle {
         font-weight: $bold-weight;
     }
-    li div {
-        display: inline-block;
-    }
     .add-icon,
     .delete-icon {
         margin-left: 5px;
@@ -1598,15 +1595,6 @@ form .edit-buttons {
         &:hover {
             color: #146714;
         }
-    }
-    .delete-icon {
-        opacity: 0;
-    }
-    li div:focus .delete-icon,
-    li div:hover .delete-icon,
-    li div a:focus + .delete-icon,
-    li div .delete-icon:focus {
-        opacity: 1;
     }
 }
 p.description {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1581,8 +1581,23 @@ form .edit-buttons {
         margin: .3em;
     }
 }
-#notebookJumbo .externalResourcesTitle {
-    font-weight:bold;
+#notebookJumbo .externalResources{
+  .externalResourcesTitle {
+      font-weight: bold;
+  }
+  a.delete-icon, a.add-icon{
+    text-decoration: none;
+  }
+  a.add-icon{
+    color: #1e841e;
+    margin-left:5px;
+  }
+  a.add-icon:hover{
+    color: #146714;
+  }
+  a.delete-icon{
+    margin-right:5px;
+  }
 }
 p.description {
     margin-bottom: .85em;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1581,6 +1581,9 @@ form .edit-buttons {
         margin: .3em;
     }
 }
+#notebookJumbo .externalResourcesTitle {
+    font-weight:bold;
+}
 p.description {
     margin-bottom: .85em;
     white-space: pre-line;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1585,26 +1585,28 @@ form .edit-buttons {
     .externalResourcesTitle {
         font-weight: $bold-weight;
     }
-    a.add-icon,
-    a.delete-icon {
+    li div {
+        display: inline-block;
+    }
+    .add-icon,
+    .delete-icon {
         margin-left: 5px;
         text-decoration: none;
     }
-    a.add-icon {
+    .add-icon {
         color: #1e841e;
         &:hover {
             color: #146714;
         }
     }
-    a.delete-icon {
-        visibility: hidden;
+    .delete-icon {
+        opacity: 0;
     }
-    li:focus .delete-icon,
-    li:hover .delete-icon,
-    li a:focus + .delete-icon,
-    li .delete-icon:focus,
-    li .delete-icon:hover {
-        visibility: visible;
+    li div:focus .delete-icon,
+    li div:hover .delete-icon,
+    li div a:focus + .delete-icon,
+    li div .delete-icon:focus {
+        opacity: 1;
     }
 }
 p.description {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1581,23 +1581,31 @@ form .edit-buttons {
         margin: .3em;
     }
 }
-#notebookJumbo .externalResources{
-  .externalResourcesTitle {
-      font-weight: $bold-weight;
-  }
-  a.delete-icon, a.add-icon{
-    text-decoration: none;
-  }
-  a.add-icon{
-    color: #1e841e;
-    margin-left:5px;
-  }
-  a.add-icon:hover{
-    color: #146714;
-  }
-  a.delete-icon{
-    margin-right:5px;
-  }
+#notebookJumbo .externalResources {
+    .externalResourcesTitle {
+        font-weight: $bold-weight;
+    }
+    a.add-icon,
+    a.delete-icon {
+        margin-left: 5px;
+        text-decoration: none;
+    }
+    a.add-icon {
+        color: #1e841e;
+        &:hover {
+            color: #146714;
+        }
+    }
+    a.delete-icon {
+        visibility: hidden;
+    }
+    li:focus .delete-icon,
+    li:hover .delete-icon,
+    li a:focus + .delete-icon,
+    li .delete-icon:focus,
+    li .delete-icon:hover {
+        visibility: visible;
+    }
 }
 p.description {
     margin-bottom: .85em;

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -424,18 +424,18 @@ class NotebooksController < ApplicationController
 
   # POST /notebooks/:uuid/resource
   def resource
-    @resource=Resource.new(notebook: @notebook, user: @user, href: params[:href], title: params[:title])
+    @resource = Resource.new(notebook: @notebook, user: @user, href: params[:href], title: params[:title])
     if @resource.title && @resource.title.length > 0 && valid_url?(@resource.href)
       @resource.save()
       flash[:success] = GalleryConfig.external_resources_label + " successfully added to the notebook."
       head :no_content
     else
-      errors=""
+      errors = ""
       if !(@resource.title && @resource.title.length > 0)
-        errors = errors + "You must specify a title for your resource.<br />"
+        errors += "You must specify a title for your resource.<br />"
       end
       if !valid_url?(@resource.href)
-        errors = errors + "You must specify a valid URL for your resource.<br />"
+        errors += "You must specify a valid URL for your resource.<br />"
       end
       render :text => errors, :status => :bad_request
     end
@@ -443,9 +443,9 @@ class NotebooksController < ApplicationController
 
   # PATCH /notebooks/:uuid/resource
   def resource=
-    @resource=Resource.where(id: params[:resource_id])
-    @resource.href=params[:href]
-    @resource.title=params[:title]
+    @resource = Resource.where(id: params[:resource_id])
+    @resource.href = params[:href]
+    @resource.title = params[:title]
     @resource.save()
     head :no_content
   end

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -424,8 +424,10 @@ class NotebooksController < ApplicationController
 
   # POST /notebooks/:uuid/resource
   def resource
-    @resource=Resource.new(params[:resource],href: params[:href],title: params[:title],notebook: @notebook)
+    @resource=Resource.new(notebook: @notebook,href: params[:href], title: params[:title])
     @resource.save()
+    flash[:success] = GalleryConfig.external_resources_label + " successfully added to the notebook."
+    head :no_content
   end
 
   # PATCH /notebooks/:uuid/resource
@@ -434,6 +436,7 @@ class NotebooksController < ApplicationController
     @resource.href=params[:href]
     @resource.title=params[:title]
     @resource.save()
+    head :no_content
   end
 
   # GET /notebooks/:uuid/tags

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -30,6 +30,7 @@ class NotebooksController < ApplicationController
     diff
     users
     reviews
+    resources
   ]
   member_readers = member_readers_anonymous + member_readers_login
   member_editors = %i[
@@ -40,6 +41,8 @@ class NotebooksController < ApplicationController
     submit_for_review
     deprecate
     remove_deprecation_status
+    resource
+    resource=
   ]
   member_owner = %i[
     destroy
@@ -412,6 +415,25 @@ class NotebooksController < ApplicationController
     @notebook.save!
     render json: { title: @notebook.title }
     flash[:success] = "Notebook title has been updated successfully."
+  end
+
+  # GET /notebooks/:uuid/resources
+  def resources
+    render json: { resources: @notebook.resources }
+  end
+
+  # POST /notebooks/:uuid/resource
+  def resource
+    @resource=Resource.new(params[:resource],href: params[:href],title: params[:title],notebook: @notebook)
+    @resource.save()
+  end
+
+  # PATCH /notebooks/:uuid/resource
+  def resource=
+    @resource=Resource.where(id: params[:resource_id])
+    @resource.href=params[:href]
+    @resource.title=params[:title]
+    @resource.save()
   end
 
   # GET /notebooks/:uuid/tags

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -424,7 +424,7 @@ class NotebooksController < ApplicationController
 
   # POST /notebooks/:uuid/resource
   def resource
-    @resource=Resource.new(notebook: @notebook,href: params[:href], title: params[:title])
+    @resource=Resource.new(notebook: @notebook, user: @user, href: params[:href], title: params[:title])
     if @resource.title && @resource.title.length > 0 && valid_url?(@resource.href)
       @resource.save()
       flash[:success] = GalleryConfig.external_resources_label + " successfully added to the notebook."

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,0 +1,17 @@
+class ResourcesController < ApplicationController
+  before_action(:verify_login)
+  before_action(:set_resource)
+  before_action(:verify_edit_or_admin)
+
+  # DELETE /resources/:id
+  def destroy
+    @resource.destroy()
+    head :no_content
+  end
+
+  def set_resource()
+    @resource = Resource.find_by('id': params[:id])
+    @notebook = Notebook.find_by('id' => @resource.notebook_id)
+    flash[:success] = GalleryConfig.external_resources_label + " successfully deleted."
+  end
+end

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -20,6 +20,7 @@ class Notebook < ActiveRecord::Base
   has_many :revisions, dependent: :destroy
   has_many :reviews, dependent: :destroy
   has_many :subscriptions, as: :sub, dependent: :destroy
+  has_many :resources, dependent: :destroy
   has_one :deprecated_notebook
 
   acts_as_commontable # dependent: :destroy # requires commontator 5.1

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,3 @@
+class Resource < ActiveRecord::Base
+  belongs_to :notebook
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,3 +1,4 @@
 class Resource < ActiveRecord::Base
   belongs_to :notebook
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,7 @@ class User < ActiveRecord::Base
   has_many :suggested_tags, dependent: :destroy
   has_many :suggested_notebooks, dependent: :destroy
   has_many :feedbacks, dependent: :nullify
+  has_many :resources, dependent: :nullify
   has_many :subscriptions, as: :sub, dependent: :destroy
 
   # Groups user belongs to

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -1,0 +1,9 @@
+-if notebook.resources.count > 0
+  div.externalResources
+    span.externalResourcesTitle #{GalleryConfig.external_resources_title}
+    -notebook.resources.each do |resource|
+      br
+      -if @user.can_edit?(@notebook) || @user.admin?
+        a.glyphicon.glyphicon-trash.tooltips.delete_resource href='#' title='Delete Resource'
+          span.sr-only Delete Resource #{resource.title}
+      a href="#{resource.href}" #{resource.title}

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -1,11 +1,12 @@
-div.externalResources
-  span.externalResourcesTitle #{GalleryConfig.external_resources_title}
-  -if @user.can_edit?(@notebook) || @user.admin?
-    a.glyphicon.glyphicon-plus.tooltips.add-icon href='#' id='add_external_resource' title='Add #{GalleryConfig.external_resources_label}'
-      span.sr-only Add New #{GalleryConfig.external_resources_label}
-  -notebook.resources.each do |resource|
-    div id="resource-#{resource.id}"
-      -if @user.can_edit?(@notebook) || @user.admin?
-        a.glyphicon.glyphicon-trash.tooltips.delete-icon href='#' title='Delete #{GalleryConfig.external_resources_label}'
-          span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
-      a href="#{resource.href}" #{resource.title}
+-if @user.can_edit?(@notebook) || @user.admin? || (@notebook.resources && @notebook.resources.count>0)
+  div.externalResources
+    span.externalResourcesTitle #{GalleryConfig.external_resources_title}
+    -if @user.can_edit?(@notebook) || @user.admin?
+      a.glyphicon.glyphicon-plus.tooltips.add-icon href='#' id='add_external_resource' title='Add #{GalleryConfig.external_resources_label}'
+        span.sr-only Add New #{GalleryConfig.external_resources_label}
+    -notebook.resources.each do |resource|
+      div id="resource-#{resource.id}"
+        -if @user.can_edit?(@notebook) || @user.admin?
+          a.glyphicon.glyphicon-trash.tooltips.delete-icon href='#' title='Delete #{GalleryConfig.external_resources_label}'
+            span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
+        a href="#{resource.href}" #{resource.title}

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -6,8 +6,7 @@
         span.sr-only Add New #{GalleryConfig.external_resources_label}
     -notebook.resources.each do |resource|
       li id="resource-#{resource.id}"
-        div
-          a href="#{resource.href}" #{resource.title}
-          -if @user.can_edit?(@notebook) || @user.admin?
-            a.glyphicon.glyphicon-trash.tooltips.delete-icon href="#" title="Delete #{GalleryConfig.external_resources_label}"
-              span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
+        a href="#{resource.href}" #{resource.title}
+        -if @user.can_edit?(@notebook) || @user.admin?
+          a.glyphicon.glyphicon-trash.tooltips.delete-icon href="#" title="Delete #{GalleryConfig.external_resources_label}"
+            span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -1,12 +1,12 @@
--if @user.can_edit?(@notebook) || @user.admin? || (@notebook.resources && @notebook.resources.count>0)
+-if @user.can_edit?(@notebook) || @user.admin? || (@notebook.resources && @notebook.resources.count > 0)
   div.externalResources
     span.externalResourcesTitle #{GalleryConfig.external_resources_title}
     -if @user.can_edit?(@notebook) || @user.admin?
-      a.glyphicon.glyphicon-plus.tooltips.add-icon href='#' id='add_external_resource' title='Add #{GalleryConfig.external_resources_label}'
+      a.glyphicon.glyphicon-plus.tooltips.add-icon href="#" id="add_external_resource" title="Add #{GalleryConfig.external_resources_label}"
         span.sr-only Add New #{GalleryConfig.external_resources_label}
     -notebook.resources.each do |resource|
-      div id="resource-#{resource.id}"
-        -if @user.can_edit?(@notebook) || @user.admin?
-          a.glyphicon.glyphicon-trash.tooltips.delete-icon href='#' title='Delete #{GalleryConfig.external_resources_label}'
-            span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
+      li id="resource-#{resource.id}"
         a href="#{resource.href}" #{resource.title}
+        -if @user.can_edit?(@notebook) || @user.admin?
+          a.glyphicon.glyphicon-trash.tooltips.delete-icon href="#" title="Delete #{GalleryConfig.external_resources_label}"
+            span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -1,9 +1,11 @@
--if notebook.resources.count > 0
-  div.externalResources
-    span.externalResourcesTitle #{GalleryConfig.external_resources_title}
-    -notebook.resources.each do |resource|
-      br
+div.externalResources
+  span.externalResourcesTitle #{GalleryConfig.external_resources_title}
+  -if @user.can_edit?(@notebook) || @user.admin?
+    a.glyphicon.glyphicon-plus.tooltips.add-icon href='#' id='add_external_resource' title='Add #{GalleryConfig.external_resources_label}'
+      span.sr-only Add New #{GalleryConfig.external_resources_label}
+  -notebook.resources.each do |resource|
+    div id="resource-#{resource.id}"
       -if @user.can_edit?(@notebook) || @user.admin?
-        a.glyphicon.glyphicon-trash.tooltips.delete_resource href='#' title='Delete Resource'
-          span.sr-only Delete Resource #{resource.title}
+        a.glyphicon.glyphicon-trash.tooltips.delete-icon href='#' title='Delete #{GalleryConfig.external_resources_label}'
+          span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
       a href="#{resource.href}" #{resource.title}

--- a/app/views/application/_external_resources.slim
+++ b/app/views/application/_external_resources.slim
@@ -6,7 +6,8 @@
         span.sr-only Add New #{GalleryConfig.external_resources_label}
     -notebook.resources.each do |resource|
       li id="resource-#{resource.id}"
-        a href="#{resource.href}" #{resource.title}
-        -if @user.can_edit?(@notebook) || @user.admin?
-          a.glyphicon.glyphicon-trash.tooltips.delete-icon href="#" title="Delete #{GalleryConfig.external_resources_label}"
-            span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}
+        div
+          a href="#{resource.href}" #{resource.title}
+          -if @user.can_edit?(@notebook) || @user.admin?
+            a.glyphicon.glyphicon-trash.tooltips.delete-icon href="#" title="Delete #{GalleryConfig.external_resources_label}"
+              span.sr-only Delete #{GalleryConfig.external_resources_label} #{resource.title}

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -421,17 +421,24 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
             button.btn.btn-success type="submit" id="addResourceFormSubmit" disabled="true" Add #{GalleryConfig.external_resources_label}
   javascript:
     $(document).ready(function(){
+      /* Not Perfect but makes sure things start cleanly and supports both IP and domain name based URLs */
       var testHref = new RegExp("^https?:\\/\\/" +
                               "((([a-z\\d-]+\\.)+(a-z){2,})||((\\d{1,3}\\.){3}\\d{1,3}))" +
                               "(\\:\\d+)?");
       $('#newResourceTitle').on('change',function(){
         validateNewResource();
       });
+      $('#newResourceTitle').on('keydown',function(){
+        validateNewResource();
+      });
       $('#newResourceHref').on('change',function(){
         validateNewResource();
       });
+      $('#newResourceHref').on('keydown',function(){
+        validateNewResource();
+      });
       function validateNewResource(){
-        if($('#newResourceTitle').val().length>5 && testHref.test($('#newResourceHref').val())){
+        if( $('#newResourceTitle').val().length > 0 && $('#newResourceHref').val().length > 11  && testHref.test($('#newResourceHref').val()) ){
           $('#addResourceFormSubmit').attr('disabled',false);
         }else{
           $('#addResourceFormSubmit').attr('disabled',true);
@@ -454,8 +461,8 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
                 },
                 error: function(response){
                   console.log(response);
-                  bootbox.hideAll();
-                  bootbox.alert('You had an error! ' + response.statusText);
+                  $('#addResourceError').html = response;
+                  $('#addResourceError').attr('hidden',false);
                 }
             });
           }

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -393,3 +393,72 @@ javascript:
                     span.sr-only
                       |  Status
                 button.btn.btn-success type="submit" id="deprecateNotebookSubmit" Deprecate Notebook
+
+
+div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-describedby="addResourceDescription" role="dialog" style="display: none" tabindex="0"
+  div.modal-dialog
+    div.modal-content
+      form id="addResourceForm" enctype="multipart/form-data" data-toggle="validator" role="form"
+        div.modal-header
+          h1.modal-title id="addResourceHeader" Add a new #{GalleryConfig.external_resources_label}
+          p.sr-only id="addResourceDescription" Dialog for adding a new #{GalleryConfig.external_resources_label}
+          button.close type="button" data-dismiss="modal"
+            span aria-hidden="true" &times;
+            span.sr-only Close Dialog
+        div.modal-body
+          div.alert.alert-danger.center hidden="true" id="addResourceError"
+          div.form-group.has-feedback
+            div.input-group
+              span.input-group-addon.upload-addon #{GalleryConfig.external_resources_label} Title
+              input.form-control id="newResourceTitle" type="text" name="resourceTitle" value="" autocomplete="off" placeholder="Title for the #{GalleryConfig.external_resources_label}"
+          div.form-group.has-feedback
+            div.input-group
+              span.input-group-addon.upload-addon #{GalleryConfig.external_resources_label} URL
+              input.form-control id="newResourceHref" type="text" name="resourceHref" value="" autocomplete="off" placeholder="URL for the #{GalleryConfig.external_resources_label}"
+          div.modal-footer
+            button.btn.btn-danger data-dismiss="modal"
+              | Cancel
+            button.btn.btn-success type="submit" id="addResourceFormSubmit" disabled="true" Add #{GalleryConfig.external_resources_label}
+  javascript:
+    $(document).ready(function(){
+      var testHref = new RegExp("^https?:\\/\\/" +
+                              "((([a-z\\d-]+\\.)+(a-z){2,})||((\\d{1,3}\\.){3}\\d{1,3}))" +
+                              "(\\:\\d+)?");
+      $('#newResourceTitle').on('change',function(){
+        validateNewResource();
+      });
+      $('#newResourceHref').on('change',function(){
+        validateNewResource();
+      });
+      function validateNewResource(){
+        if($('#newResourceTitle').val().length>5 && testHref.test($('#newResourceHref').val())){
+          $('#addResourceFormSubmit').attr('disabled',false);
+        }else{
+          $('#addResourceFormSubmit').attr('disabled',true);
+        }
+      }
+      /* Placed here because I need to use ruby vars*/
+      $('.externalResources .delete-icon').click(function(event){
+        event.preventDefault();
+        console.log(event.currentTarget.parentNode);
+        resource_id=event.currentTarget.parentNode.id.replace("resource-","");
+        bootbox.confirm("Are you sure you want to delete this #{GalleryConfig.external_resources_label}?", function(userResponse){
+          if (userResponse == true){
+            bootboxPending('Deleting Resource!');
+            $.ajax({
+                url: '/resources/' + resource_id,
+                type: 'DELETE',
+                success: function(response){
+                  bootbox.hideAll();
+                  location.reload();
+                },
+                error: function(response){
+                  console.log(response);
+                  bootbox.hideAll();
+                  bootbox.alert('You had an error! ' + response.statusText);
+                }
+            });
+          }
+        })
+      });
+    });

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -419,9 +419,10 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
             button.btn.btn-danger data-dismiss="modal"
               | Cancel
             button.btn.btn-success type="submit" id="addResourceFormSubmit" disabled="true" Add #{GalleryConfig.external_resources_label}
+
   javascript:
     $(document).ready(function(){
-      /* Not Perfect but makes sure things start cleanly and supports both IP and domain name based URLs */
+      /* Not perfect but makes sure things start cleanly and supports both IP and domain name based URLs */
       var testHref = new RegExp("^https?:\\/\\/" +
                               "((([a-z\\d-]+\\.)+(a-z){2,})||((\\d{1,3}\\.){3}\\d{1,3}))" +
                               "(\\:\\d+)?");
@@ -440,30 +441,37 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
       function validateNewResource(){
         if( $('#newResourceTitle').val().length > 0 && $('#newResourceHref').val().length > 11  && testHref.test($('#newResourceHref').val()) ){
           $('#addResourceFormSubmit').attr('disabled',false);
-        }else{
+        }
+        else{
           $('#addResourceFormSubmit').attr('disabled',true);
         }
       }
+
       /* Placed here because I need to use ruby vars*/
-      $('.externalResources .delete-icon').click(function(event){
-        event.preventDefault();
-        console.log(event.currentTarget.parentNode);
-        resource_id=event.currentTarget.parentNode.id.replace("resource-","");
+      $('.externalResources .delete-icon').keypress(function(e){
+        var keycode = (e.keyCode ? event.keyCode : event.which);
+        if(keycode == '13' || keycode == '32'){
+          e.preventDefault();
+          $(this).click();
+        }
+      });
+      $('.externalResources .delete-icon').click(function(e){
+        e.preventDefault();
+        resource_id = event.currentTarget.parentNode.id.replace("resource-","");
         bootbox.confirm("Are you sure you want to delete this #{GalleryConfig.external_resources_label}?", function(userResponse){
           if (userResponse == true){
             bootboxPending('Deleting Resource!');
             $.ajax({
-                url: '/resources/' + resource_id,
-                type: 'DELETE',
-                success: function(response){
-                  bootbox.hideAll();
-                  location.reload();
-                },
-                error: function(response){
-                  console.log(response);
-                  $('#addResourceError').html = response;
-                  $('#addResourceError').attr('hidden',false);
-                }
+              url: '/resources/' + resource_id,
+              type: 'DELETE',
+              success: function(response){
+                bootbox.hideAll();
+                location.reload();
+              },
+              error: function(response){
+                $('#addResourceError').html = response;
+                $('#addResourceError').attr('hidden',false);
+              }
             });
           }
         })

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -207,6 +207,7 @@ div.content-container
             ==link_to_user(@notebook.updater)
 
         ==render partial: "tags_edit", locals: { notebook: @notebook }
+        ==render partial: "external_resources", locals: { notebook: @notebook } 
 
     hr.divider.new-divider.show style="display: none"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do # rubocop: disable Metrics/BlockLength
   # Warning/notification banner
   resource :warning, only: %i[show create destroy], path: '/admin/warning'
 
+  resources :resources, only: %i[destroy]
+
   # Change requests
   resources :change_requests, except: %i[new edit update] do
     member do
@@ -86,6 +88,9 @@ Rails.application.routes.draw do # rubocop: disable Metrics/BlockLength
       get 'description'
       patch 'description' => 'notebooks#description='
       post 'feedback'
+      post 'resource'
+      get 'resources'
+      patch 'resource' => 'notebooks#resource='
       get 'wordcloud.png' => 'notebooks#wordcloud'
       post 'diff'
       get 'filter_owner'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -237,3 +237,4 @@ oauth_provider_enabled: false
 #    - domain/ip[:port] for other gallery
 anonymous_access: true
 
+external_resources_title: "External Resources"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -237,4 +237,7 @@ oauth_provider_enabled: false
 #    - domain/ip[:port] for other gallery
 anonymous_access: true
 
+#Collection of resources title
 external_resources_title: "External Resources"
+#Individual resource label
+external_resources_label: "External Resource"

--- a/db/migrate/20200903122609_create_resources.rb
+++ b/db/migrate/20200903122609_create_resources.rb
@@ -1,0 +1,11 @@
+class CreateResources < ActiveRecord::Migration
+  def change
+    create_table :resources do |t|
+      t.string :href
+      t.string :title
+      t.references :notebook, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20200903122609_create_resources.rb
+++ b/db/migrate/20200903122609_create_resources.rb
@@ -4,6 +4,7 @@ class CreateResources < ActiveRecord::Migration
       t.string :href
       t.string :title
       t.references :notebook, index: true, foreign_key: true
+      t.references :user, index: true, foreign_key: true
 
       t.timestamps null: false
     end

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  href: MyString
+  title: MyString
+  notebook_id: 
+
+two:
+  href: MyString
+  title: MyString
+  notebook_id: 

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ResourceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
@manfromjupyter Take a look through this.  The "External Links" section only appears if
a) There are links or
b) The user viewing the notebook has edit priv (including admin) so they have access to the + icon

Dialog copies error message method from a different dialog, so should be accessible, unless I copied one that wasn't.

Simplistic Javascript validation and more robust validation for URL on the backend
Doesn't prevent double posting right now but, they are easy to delete...What if they want two titles to the same doc or something.

Closes #153 