### PR TITLE
Change devise alert and notice to error and info for proper display

### DIFF
--- a/app/views/application/_alert_container.slim
+++ b/app/views/application/_alert_container.slim
@@ -1,10 +1,10 @@
 -if !flash.empty?
   div.content-container.alert-container
     -flash.each do |key, value|
-      - if key == "alert"
-        - key = "error"
-      - if key == "notice"
-        - key = "info"
+      -if key == "alert"
+        -key = "error"
+      -if key == "notice"
+        -key = "info"
       div class="alert alert-#{key} content-body-alert" role="alert"
         -if key == "success"
           i.fa.fa-check-circle aria-hidden="true"

--- a/app/views/application/_alert_container.slim
+++ b/app/views/application/_alert_container.slim
@@ -1,6 +1,10 @@
 -if !flash.empty?
   div.content-container.alert-container
     -flash.each do |key, value|
+      - if key == "alert"
+        - key = "error"
+      - if key == "notice"
+        - key = "info"
       div class="alert alert-#{key} content-body-alert" role="alert"
         -if key == "success"
           i.fa.fa-check-circle aria-hidden="true"


### PR DESCRIPTION
Closes #309 

This is built into devise (it only returns notice and alert) and the only way to fix this is a little hacky - https://stackoverflow.com/questions/32444342/devise-flash-message-being-notice