### PR TITLE
Minor fixes to themes, reviews autonomination, error handling in a couple modals, and editor permissioning

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -3311,11 +3311,15 @@ body.dark-theme {
         }
     }
     #notebookJumbo {
-        .glyphicon:not(.author-rep),
-        .action-icon:not(.fa-medkit),
-        .badge,
-        .caret {
-            color: $secondary-background;
+        .notebook-actions,
+        #tagsDisplay,
+        .tags-edit-mode {
+            .glyphicon:not(.author-rep),
+            .action-icon:not(.fa-medkit),
+            .badge,
+            .caret {
+                color: $secondary-background;
+            }
         }
         #notebookGearActions .glyphicon {
             color: $intermediate-icon-color;
@@ -3335,6 +3339,9 @@ body.dark-theme {
         strong {
             color: $secondary-background;
         }
+    }
+    .externalResources {
+        color: #fff;
     }
 }
 
@@ -3403,18 +3410,22 @@ body.ultra-dark-theme {
     .comment_delete_link,
     .tagLogoLock,
     a.skip,
-    /* =================================================================== */
-    /* When we remove tooltip popup on search next release, uncomment this */
-    /* &.page-home .tabs .tabLink.active, */
-    /* =================================================================== */
     .logo-loading,
     .glyphicon-alert,
     .banner,
     .super-container,
     &.path-video video,
     #navbarSearchBar .info-button,
-    #expandableSearchDropdown {
+    #expandableSearchDropdown,
+    .add-icon {
         filter: invert(100%);
+    }
+    .modal-header {
+        .close:hover,
+        .close:focus {
+            filter: invert(100%);
+            text-shadow: none;
+        }
     }
     &.page-users-id .carousel-inner .author-rep,
     #addFilterFormContainer .button-container.no-header button {
@@ -3435,13 +3446,10 @@ body.ultra-dark-theme {
             filter: invert(0);
         }
     }
-    /* =================================================================== */
-    /* When we remove tooltip popup on search next release, uncomment this */
-    .tabs.active .tabLink {
+    .tab.active .tabLink {
         color: #0098fc;
         border-bottom: 0.4em solid #0098fc;
     }
-    /* =================================================================== */
 }
 
 /* ===== LARGER TEXT MODE ===== */

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -42,11 +42,11 @@ class NotebooksController < ApplicationController
     remove_deprecation_status
     resource
     resource=
+    shares=
+    public=
   ]
   member_owner = %i[
     destroy
-    shares=
-    public=
     owner=
   ]
   member_methods = member_readers + member_editors + member_owner + [:create]

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -182,9 +182,11 @@ class Review < ActiveRecord::Base
 
       # Don't add if it's already in the queue, but update revision and comments
       if latest_review.status == 'queued'
-        latest_review.revision = latest_revision
-        latest_review.comments = comments
-        latest_review.save
+        if latest_review.revision != latest_revision
+          latest_review.comments = comments
+          latest_review.revision = latest_revision
+          latest_review.save
+        end
         return false
       end
 

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -356,6 +356,7 @@ javascript:
                 -else
                   textarea.form-control name="comments" id="deprecateNotebookReasoning" placeholder="Enter why this notebook is being deprecated" required=true
                     ==@notebook.deprecated_notebook.reasoning
+              div.help-block.with-errors
             div.form-group
               div.input-group
                 span.input-group-addon.upload-addon Recommended Alternate Notebook(s)
@@ -411,10 +412,12 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
             div.input-group
               span.input-group-addon.upload-addon #{GalleryConfig.external_resources_label} Title
               input.form-control id="newResourceTitle" type="text" name="resourceTitle" value="" autocomplete="off" placeholder="Title for the #{GalleryConfig.external_resources_label}"
+            div.help-block.with-errors
           div.form-group.has-feedback
             div.input-group
               span.input-group-addon.upload-addon #{GalleryConfig.external_resources_label} URL
               input.form-control id="newResourceHref" type="text" name="resourceHref" value="" autocomplete="off" placeholder="URL for the #{GalleryConfig.external_resources_label}"
+            div.help-block.with-errors
           div.modal-footer
             button.btn.btn-danger data-dismiss="modal"
               | Cancel

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -104,19 +104,19 @@ div.content-container
               -if @user.can_edit?(@notebook, true)
                 li.divider
                 li.dropdown-header.filter-item #{(@user.owner(@notebook)? "Owner Actions" : "Editor Actions")}
+                li
+                  a href="#" id="publicToggle"
+                    span id="publicToggleGlyph" class="gear-dropdown-icon glyphicon glyphicon-#{@notebook.public ? 'lock' : 'globe'}" aria-hidden="true"
+                    span id="publicToggleText" #{@notebook.public ? "Make private" : "Make public"}
                 -if @user.owner(@notebook)
-                  li
-                    a href="#" id="publicToggle"
-                      span id="publicToggleGlyph" class="gear-dropdown-icon glyphicon glyphicon-#{@notebook.public ? 'lock' : 'globe'}" aria-hidden="true"
-                      span id="publicToggleText" #{@notebook.public ? "Make private" : "Make public"}
                   li
                     a.modal-activate href="#changeOwnerModal" id="changeOwner" data-toggle="modal"
                       span.gear-dropdown-icon.glyphicon.glyphicon-user aria-hidden="true"
                       | Change ownership
-                  li
-                    a.modal-activate href="#sharingModal" id="shareNotebookButton" data-toggle="modal"
-                      span.glyphicon.glyphicon-plus.gear-dropdown-icon aria-hidden="true"
-                      | Share notebook with individuals
+                li
+                  a.modal-activate href="#sharingModal" id="shareNotebookButton" data-toggle="modal"
+                    span.glyphicon.glyphicon-plus.gear-dropdown-icon aria-hidden="true"
+                    | Share notebook with individuals
                 li
                   a.modal-activate href="#editNotebookModal" id="editNotebook" data-toggle="modal"
                     span.gear-dropdown-icon.glyphicon.glyphicon-upload aria-hidden="true"
@@ -207,7 +207,7 @@ div.content-container
             ==link_to_user(@notebook.updater)
 
         ==render partial: "tags_edit", locals: { notebook: @notebook }
-        ==render partial: "external_resources", locals: { notebook: @notebook } 
+        ==render partial: "external_resources", locals: { notebook: @notebook }
 
     hr.divider.new-divider.show style="display: none"
 


### PR DESCRIPTION
- Fixed home page and External Resources for ultra dark theme
- Fixed autonomination nightly_computation of reviews so already queued notebooks aren't recreated again causing subscription emails to keep sending off every morning despite there not being any new change.
- Added error block placeholders in the External Resource modal and Deprecation Status Banner
- Gave users with editor permissions on notebooks the ability toggle public/private and share with other users.