### PR TITLE
Email Notebook doesn't cause '#' to appear in URL now.

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -452,7 +452,8 @@ $(document).ready(function(){
     });
   });
 
-  $('#emailNotebook').on('click',function(){
+  $('#emailNotebook').on('click',function(e){
+    e.preventDefault();
     bootboxPending('An email should pop-up shortly!');
     $.ajax({
       method: 'GET',


### PR DESCRIPTION
Might look like it's broken when testing but before this change, clicking it causes a little stutter and then it doesn't open. Just think it has to do with my environment of this and emails not working right so far.

Closes #324 