### PR TITLE
GITHUB-323: Deprecated Notebook's SQL table reasoning column no longer return Errors

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -568,6 +568,23 @@ $(document).ready(function(){
     });
     return false;
   });
+  $('#deprecateNotebookReasoning').keyup(function(){
+    maxlength = 500;
+    length = this.value.length;
+    $('#deprecateNotebookForm .remaining-characters-warning').html( 'Remaining characters: ' + ( maxlength - length ));
+    if (maxlength <= length) {
+      $('#deprecateNotebookForm .remaining-characters-warning').addClass('error');
+    }
+    else {
+      $('#deprecateNotebookForm .remaining-characters-warning').removeClass('error');
+    }
+    if (maxlength - length < 50) {
+      $('#deprecateNotebookForm .remaining-characters-warning').css('display','block');
+    }
+    else {
+      $('#deprecateNotebookForm .remaining-characters-warning').css('display','none');
+    }
+  })
 
   $('#proposeReviewForm').on('submit',function(){
     $('#proposeReviewSubmit').attr('disabled', true);

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -91,6 +91,14 @@ textarea.form-control {
 .modal-header .close {
     box-shadow: none;
 }
+.remaining-characters-warning {
+    color: #555;
+    display: block;
+    text-align: right;
+    &.error {
+        color: $error-text-color;
+    }
+}
 
 /* Base Styles - Loading Modals */
 .loading-modal {
@@ -101,6 +109,7 @@ textarea.form-control {
         font-size: 110%;
     }
 }
+
 
 /* Base Styles - JavaScript Generated */
 .bootbox.modal {

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -352,10 +352,11 @@ javascript:
               div.input-group
                 span.input-group-addon.upload-addon Reasoning
                 -if @notebook.deprecated_notebook == nil
-                  textarea.form-control name="comments" id="deprecateNotebookReasoning" placeholder="Enter why this notebook is being deprecated" required=true
+                  textarea.form-control name="comments" id="deprecateNotebookReasoning" placeholder="Enter why this notebook is being deprecated" maxlength="500" required=true
                 -else
-                  textarea.form-control name="comments" id="deprecateNotebookReasoning" placeholder="Enter why this notebook is being deprecated" required=true
+                  textarea.form-control name="comments" id="deprecateNotebookReasoning" placeholder="Enter why this notebook is being deprecated" maxlength="500" required=true
                     ==@notebook.deprecated_notebook.reasoning
+              span.remaining-characters-warning
             div.form-group
               div.input-group
                 span.input-group-addon.upload-addon Recommended Alternate Notebook(s)

--- a/db/migrate/20201014151211_change_reasoning_to_be_text_in_deprecated_notebooks.rb
+++ b/db/migrate/20201014151211_change_reasoning_to_be_text_in_deprecated_notebooks.rb
@@ -1,0 +1,9 @@
+class ChangeReasoningToBeTextInDeprecatedNotebooks < ActiveRecord::Migration
+  def up
+    change_column :deprecated_notebooks, :reasoning, :text
+  end
+
+  def down
+    change_column :deprecated_notebooks, :reasoning, :string
+  end
+end


### PR DESCRIPTION
Switched Deprecated Notebook's SQL table reasoning column from t.string to t.text so will no longer return rails/MYSQL error: 'ActiveRecord::StatementInvalid - Data too long for column'

Test by either inspecting deprecate_notebooks table or adding a huge amount of text to a deprecation status.

Closes: #323 