### PR TITLE
GITHUB-335: Fixed it so notebooks with bad html don't cause code blocks to break

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2552,6 +2552,7 @@ body.page-users table th .form-control {
 #notebookDisplay,
 body.page-code_cells-id {
     .cell-health {
+        display: block;
         outline: none;
         position: relative;
         right: 20px;


### PR DESCRIPTION
Closes #335 
Can test by going to /notebooks/41-typsetting-equations.
And then for sanity can check a code cells page. Those are the only places with these elements.

Before:
![some notebooks with bad html cause code blocks to break](https://user-images.githubusercontent.com/51969207/96742605-18ab5780-1391-11eb-9a11-79a6e2685f38.PNG)

After:
![applying a display block to the  cell-health](https://user-images.githubusercontent.com/51969207/96742618-1c3ede80-1391-11eb-8c8d-daf6d0e7d00f.PNG)