### PR TITLE
GITHUB-334: Update docker-compose YAML to use more recent base-image instead of Alpine

### DIFF
--- a/docker-compose-with-jupyter.yml
+++ b/docker-compose-with-jupyter.yml
@@ -2,13 +2,12 @@ version: "3"
 
 services:
   jupyter:
-    image: nbgallery/jupyter-alpine
+    image: nbgallery/base-notebook
     ports:
-      - "80:80"
+      - "80:8888"
     environment:
       NBGALLERY_URL: http://localhost:3000
       NBGALLERY_CONFIG_TOKEN: ${NBGALLERY_CONFIG_TOKEN}
       NBGALLERY_CONFIG_PASSWORD: ${NBGALLERY_CONFIG_PASSWORD}
       NBGALLERY_ENABLE_INSTRUMENTATION: 1
       NBGALLERY_ENABLE_AUTODOWNLOAD: 1
-    entrypoint: jupyter notebook --allow-root

--- a/docker-compose-with-jupyter.yml
+++ b/docker-compose-with-jupyter.yml
@@ -4,10 +4,8 @@ services:
   jupyter:
     image: nbgallery/base-notebook
     ports:
-      - "80:8888"
+      - "8888:8888"
     environment:
       NBGALLERY_URL: http://localhost:3000
-      NBGALLERY_CONFIG_TOKEN: ${NBGALLERY_CONFIG_TOKEN}
-      NBGALLERY_CONFIG_PASSWORD: ${NBGALLERY_CONFIG_PASSWORD}
       NBGALLERY_ENABLE_INSTRUMENTATION: 1
       NBGALLERY_ENABLE_AUTODOWNLOAD: 1


### PR DESCRIPTION
This should be a very simple swap and everything seems to work with the base-image just swapped in. This should fix #334 