### PR TITLE
Jupyter Classic vs Jupyter Lab UI for "Run"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .env
 .bundle
 /vendor/bundle
+/vendor/cache
 *.key
 *.pem
 

--- a/app/assets/javascripts/run_in_jupyter.js.erb
+++ b/app/assets/javascripts/run_in_jupyter.js.erb
@@ -44,12 +44,13 @@ $(document).ready(function() {
       success: function(response) {
         if (response.length == '1'){
           var url = response[0].url;
-          get_notebook(url,id,type,ref);
+          var user_interface = response[0].user_interface
+          get_notebook(url,id,type,ref,user_interface);
         }
         else if (response.length > '1'){
           var content = '<table class="table"><form id="environmentSelectedForm">'
           for(var i=0; i<response.length; i++){
-            content += '<tr><td><input type="radio" name="selectedUrl" value="' + response[i].url + '" />&nbsp;</td><td>' + response[i].name + '</td><td>' + response[i].url + '</td></tr>';
+            content += '<tr><td><input type="radio" name="selectedEnvironment" value="' + response[i].url + '--' + response[0].user_interface + '" />&nbsp;</td><td>' + response[i].name + '</td><td>' + response[i].url + '</td></tr>';
           }
           content += "</form></table>"
           bootbox.hideAll();
@@ -60,8 +61,11 @@ $(document).ready(function() {
               yes:{
                 label: 'select',
                 callback: function(){
-                  var url = $("input[name='selectedUrl']:checked").val();
-                  get_notebook(url,id,type,ref)
+                  var environment = $("input[name='selectedEnvironment']:checked").val();
+                  var temp = environment.split('--');
+                  var url = temp[0];
+                  var user_interface = temp[1];
+                  get_notebook(url,id,type,ref,user_interface)
                 }
               }
             }
@@ -80,7 +84,7 @@ $(document).ready(function() {
   });
 
 
-  var get_notebook = function(url,id,type,ref){
+  var get_notebook = function(url,id,type,ref,user_interface){
     if(url == undefined) {
       bootbox.hideAll();
       bootbox.dialog({
@@ -95,14 +99,14 @@ $(document).ready(function() {
         if(type == 'notebook'){
           $.get('/notebooks/' + id + '/download?run=true' + ref, function(notebook) {
             var name = (metadata['title'] + '.ipynb').replace(/\//g,'∕');
-            check_for_existence(name,url,notebook);
+            check_for_existence(name,url,notebook,user_interface);
           });
         }
         else{
           $.get('/change_requests/' + change_id + '/download?run=true', function(notebook) {
             var name = (metadata['title'] + ' (Change Request: ' + change_id.substr(0,7) + ') .ipynb').replace(/\//g,'∕');
 
-            check_for_existence(name,url,notebook);
+            check_for_existence(name,url,notebook,user_interface);
 
           });
         }
@@ -110,7 +114,7 @@ $(document).ready(function() {
     }
   }
 
-  var check_for_existence = function(name,url,notebook) {
+  var check_for_existence = function(name,url,notebook,user_interface) {
     $.ajax({
       method: 'GET',
       url: url + 'api/contents/' + encodeURIComponent(name),
@@ -129,7 +133,7 @@ $(document).ready(function() {
               label: "Overwrite",
               className: 'btn-danger',
               callback: function(){
-                send(name,url,notebook);
+                send(name,url,notebook,user_interface);
               }
             }
           }
@@ -137,12 +141,12 @@ $(document).ready(function() {
       },
       error: function(response){
         console.log(response);
-        send(name,url,notebook);
+        send(name,url,notebook,user_interface);
       }
     });
   };
 
-  var send = function(name,url,notebook) {
+  var send = function(name,url,notebook,user_interface) {
     // this SHOULD be a PUT to api/contents/NotebookName.ipynb, but since FireFox won't
     // PKI-enable an OPTIONS request, and an OPTIONS request is necessary on PUTs, we
     // have a server-side extension that proxies the PUT through a POST.
@@ -152,7 +156,13 @@ $(document).ready(function() {
       contentType: 'application/json',
       success: function() {
         bootbox.hideAll();
-        window.open(url + 'notebooks/' + encodeURIComponent(name), '_blank');
+        console.log("User Interface "+user_interface);
+        if(user_interface == 'lab'){
+          window.open(url + 'lab/tree/' + encodeURIComponent(name), '_blank');
+        }else{
+            window.open(url + 'notebooks/' + encodeURIComponent(name), '_blank');
+        }
+
       },
       error: function(response) {
         bootbox.hideAll();

--- a/app/controllers/environments_controller.rb
+++ b/app/controllers/environments_controller.rb
@@ -71,7 +71,13 @@ class EnvironmentsController < ApplicationController
     @environment.name = params[:name].strip if params[:name].present?
     @environment.url = params[:url].strip if params[:url].present?
     @environment.default = params[:default].to_bool
-
+    # The usersave paramter is how we tell the difference between a user saving
+    # the form versus the environment registration pligin triggering again.
+    if(@environment.new_record? || params[:usersave])
+      if params[:user_interface].present?
+        @environment.user_interface = params[:user_interface].strip
+      end
+    end
     if @environment.save
       if @environment.default
         # Set all other environments to non-default

--- a/app/views/environments/_environment.json.jbuilder
+++ b/app/views/environments/_environment.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! environment, :name, :url, :default
+json.extract! environment, :name, :url, :default, :user_interface

--- a/app/views/environments/_jupyter_user_interface.slim
+++ b/app/views/environments/_jupyter_user_interface.slim
@@ -1,0 +1,4 @@
+-if user_interface == "lab"
+  | Jupyter Lab
+-else
+  | Jupyter Classic

--- a/app/views/environments/index.slim
+++ b/app/views/environments/index.slim
@@ -44,6 +44,7 @@ div.content-container
         th Default
         th Name
         th Url
+        th Interface
         th Last Updated
         th Actions
     tbody
@@ -62,6 +63,7 @@ div.content-container
                 span.sr-only Row is not set as default Jupyter environment
             td ==environment.name
             td ==environment.url
+            td ==render partial: "jupyter_user_interface", locals: {user_interface: environment.user_interface}
             td ==render partial: "time_ago", locals: {time: environment.updated_at}
             td
               a.editEnvironment.modal-activate href="#" data-environmentName="#{environment.name}"

--- a/app/views/environments/modal.slim
+++ b/app/views/environments/modal.slim
@@ -39,6 +39,12 @@ form id='environmentsForm' data-toggle='validator' role='form'
         span.input-group-addon.upload-addon URL
         input.form-control type='text' name='url' placeholder="https://example.com" value="#{@environment.url}" required=true
     div.form-group
+      div.input-group
+        span.input-group-addon.upload-addon Jupyter Interface
+        select.form-control name="user_interface" id="jupyterEnvironmentInterface"
+          option[value="classic" selected=("selected" if @environment.user_interface!="lab")] Classic Jupyter
+          option[value="lab" selected=("selected" if @environment.user_interface=="lab")] Jupyter Lab
+    div.form-group
       div.alert.alert-info
         div class="checkbox"
           label
@@ -49,6 +55,7 @@ form id='environmentsForm' data-toggle='validator' role='form'
             p Make this the default Environment
     div.modal-footer
       div class="form-group"
+        input type='hidden' name='usersave' value='true'
         button.btn.btn-danger type="button" data-dismiss="modal" Cancel
         button.btn.btn-success type="submit"
           -if @environment.url != nil

--- a/db/migrate/20201106152806_add_interface_to_environment.rb
+++ b/db/migrate/20201106152806_add_interface_to_environment.rb
@@ -1,0 +1,5 @@
+class AddInterfaceToEnvironment < ActiveRecord::Migration
+  def change
+    add_column :environments, :user_interface, :string
+  end
+end


### PR DESCRIPTION
Allow extensions to set which Jupyter UI notebooks should open in
Allow users to specify what UI they want their "Run in Jupyter" button to use
Compatible with jupyterlab-nbgallery 0.2.0a3 and above Jupyterlab extensions
Closes #279 

Note: Allows for us to change the default in the future for users who haven't changed the value for their "classic" environments (because those still default to NULL from the extension, but can be manually forced to classic by editing the environment)
Will not change it just because they visit Lab (only new environments created as a result of going to Lab are set to lab)