### PR TITLE
Allow users who are part of a group to be deleted

### DIFF
--- a/db/migrate/20201118162416_add_primary_to_groups_users.rb
+++ b/db/migrate/20201118162416_add_primary_to_groups_users.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToGroupsUsers < ActiveRecord::Migration
+  def change
+    add_column :groups_users, :id, :primary_key
+  end
+end


### PR DESCRIPTION
Closes #357 
Intermediate tables MUST have singular primary key in order to be used in a cascading delete it seems.