### PR TITLE
Change to bootstrap-datepicker for styling reasons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'sdoc', group: :doc
 
 gem 'acts_as_votable'
 gem 'bootstrap-sass'
+gem 'bootstrap-datepicker-rails'
 gem 'browser'
 gem 'chartkick'
 gem 'commontator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     backports (3.11.4)
     bcrypt (3.1.13)
+    bootstrap-datepicker-rails (1.9.0.1)
+      railties (>= 3.0)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -375,6 +377,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   acts_as_votable
+  bootstrap-datepicker-rails
   bootstrap-sass
   browser
   chartkick

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,6 +16,7 @@
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 //= require jquery-ui.min
+//= require bootstrap-datepicker
 //= require bootstrap-sprockets
 //= require bootstrap-tokenfield.min
 //= require validator.min

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -1,5 +1,9 @@
 $(document).ready(function(){
 
+  //Solve Datepicker Conflict
+  var datepicker = $.fn.datepicker.noConflict(); // return $.fn.datepicker to previously assigned value
+  $.fn.bootstrapDatepicker = datepicker;         // give $().bootstrapDatepicker the bootstrap-datepicker functionality
+
   /* ===================================== */
   /* == Header-Compliance Functionality == */
   /* ===================================== */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
  @import 'bootstrap-sprockets';
  @import 'bootstrap';
  @import 'bootstrap/theme';
+ @import 'bootstrap-datepicker';
  @import 'font-awesome';
  @import 'jquery-ui.min';
  @import 'bootstrap-tokenfield.min';

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -137,11 +137,21 @@ select {
         color: #000;
     }
 }
-
-/* Without this the datepicker would pick a size larger than the input field which
-was a problem on the admin warming page */
-div.datepicker{
-  max-width:400px;
+div.datepicker {
+    border-left: 0;
+    border-right: 0;
+    margin: 0;
+    max-width: 350px;
+    padding: 0;
+    .table-condensed > thead > tr > th,
+    .table-condensed > thead > tr > td,
+    .table-condensed > tbody > tr > th,
+    .table-condensed > tbody > tr > td,
+    .table-condensed > tfoot > tr > th,
+    .table-condensed > tfoot > tr > td {
+        border-radius: 0;
+        padding: 3px 1px;
+    }
 }
 
 /* ===== Button Styles ===== */

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -138,6 +138,12 @@ select {
     }
 }
 
+/* Without this the datepicker would pick a size larger than the input field which
+was a problem on the admin warming page */
+div.datepicker{
+  max-width:400px;
+}
+
 /* ===== Button Styles ===== */
 button, .btn {
     box-shadow: $button-box-shadow;

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -1,7 +1,7 @@
 javascript:
   $(document).ready(function(){
-      $('#summaryTimeStart').datepicker();
-      $('#summaryTimeEnd').datepicker();
+      $('#summaryTimeStart').bootstrapDatepicker({autoclose:true});
+      $('#summaryTimeEnd').bootstrapDatepicker({autoclose:true});
   });
 
 div.content-container

--- a/app/views/warnings/show.slim
+++ b/app/views/warnings/show.slim
@@ -19,7 +19,7 @@ javascript:
       return false;
     });
 
-    $('#warningExpires').datepicker();
+    $('#warningExpires').bootstrapDatepicker({autoclose:true});
 
     $('#warningDelete').click(function(){
       var url = '/admin/warning';


### PR DESCRIPTION
This datepicker uses glyphicons and can more easily be styled

Possible solution to #352 by using a different, non-image based, datepicker

The max-width is because the datepicker seems to build it's size as a factor of the input field width and the input field for the warnings page is massively long.