### PR TITLE
Old title character parsing

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2221,12 +2221,12 @@ body.page-notebook-search {
         z-index: 1000;
     }
     .external-gallery .run_jupyter {
-      display:none;
+        display: none;
     }
 }
 
-body.page-home .alert,
-body.page-notebook-search .alert {
+body.page-home #main .alert,
+body.page-notebook-search #main .alert {
     margin: .75em 0 -.5em;
 }
 body.page-notebook-search h1 {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -586,6 +586,21 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  def notebook_title_character_cleanse
+    if @notebook.title.include?(":") || @notebook.title.include?("/") || @notebook.title.include?("\\")
+      if @notebook.title.include?(":")
+        @notebook.title.gsub!(":", "꞉")
+      end
+      if @notebook.title.include?("/")
+        @notebook.title.gsub!("/", "／")
+      end
+      if @notebook.title.include?("\\")
+        @notebook.title.gsub!("\\", "＼")
+      end
+      @notebook.save!
+    end
+  end
+
   # Helper to get the notebook+summary+suggestion join with page/sort params.
   # Anything that uses the 'notebooks' partial view should probably use this.
   # Note: sometimes the resulting query doesn't work well with count/empty?/etc

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -154,7 +154,7 @@ class ChangeRequestsController < ApplicationController
     else
       # Rollback the content storage
       @notebook.content = old_content
-      # render json: @notebook.errors, status: :unprocessable_entity
+      render json: @notebook.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -117,9 +117,10 @@ class ChangeRequestsController < ApplicationController
   def accept
     # Content must be validated again in the context of the owner
     jn = @change_request.proposed_notebook
-    raise Noteboook::BadUpload.new('bad content', jn.errors) if jn.invalid?(@notebook, @user, params)
+    raise Notebook::BadUpload.new('bad content', jn.errors) if jn.invalid?(@notebook, @user, params)
 
     # Update notebook object
+    notebook_title_character_cleanse()
     @notebook.lang, @notebook.lang_version = jn.language
     @notebook.updater = @change_request.requestor
     Notebook.extension_attributes.each do |attr|
@@ -153,7 +154,7 @@ class ChangeRequestsController < ApplicationController
     else
       # Rollback the content storage
       @notebook.content = old_content
-      render json: @notebook.errors, status: :unprocessable_entity
+      # render json: @notebook.errors, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -133,6 +133,16 @@ class NotebooksController < ApplicationController
   # PATCH/PUT /notebooks/:uuid
   def update
     # Parse, validate, prep for storage
+    Rails.logger.debug('>')
+    Rails.logger.debug('>')
+    Rails.logger.debug('>')
+    if @notebook.title.include?(":")
+      @notebook.title.gsub!(":", "꞉")
+      @notebook.save!
+    end
+    Rails.logger.debug('<')
+    Rails.logger.debug('<')
+    Rails.logger.debug('<')
     @old_content = @notebook.content
     @tags = parse_tags
     populate_notebook

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -133,16 +133,7 @@ class NotebooksController < ApplicationController
   # PATCH/PUT /notebooks/:uuid
   def update
     # Parse, validate, prep for storage
-    Rails.logger.debug('>')
-    Rails.logger.debug('>')
-    Rails.logger.debug('>')
-    if @notebook.title.include?(":")
-      @notebook.title.gsub!(":", "꞉")
-      @notebook.save!
-    end
-    Rails.logger.debug('<')
-    Rails.logger.debug('<')
-    Rails.logger.debug('<')
+    notebook_title_character_cleanse()
     @old_content = @notebook.content
     @tags = parse_tags
     populate_notebook
@@ -379,6 +370,7 @@ class NotebooksController < ApplicationController
       else
         User.find_by!(user_name: params[:owner])
       end
+    notebook_title_character_cleanse()
     if @notebook.save
       if params[:owner].start_with?('group:')
         flash[:success] = "Owner of notebook has been set to group: \"#{Group.find_by!(gid: params[:owner][6..-1]).name}\" successfully."

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -42,6 +42,7 @@ class StagesController < ApplicationController
     # failing on upload dialog part 2, but the UI doesn't handle the error well
     #raise Notebook::BadUpload, 'new content is the same as the original' if
     #  params[:id] && jn.pretty_json == nb.content
+
     # Store on disk and db
     staging_id = SecureRandom.uuid
     @stage = Stage.new(uuid: staging_id, user: @user)

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -42,7 +42,6 @@ class StagesController < ApplicationController
     # failing on upload dialog part 2, but the UI doesn't handle the error well
     #raise Notebook::BadUpload, 'new content is the same as the original' if
     #  params[:id] && jn.pretty_json == nb.content
-
     # Store on disk and db
     staging_id = SecureRandom.uuid
     @stage = Stage.new(uuid: staging_id, user: @user)

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -27,7 +27,7 @@ class Notebook < ActiveRecord::Base
   acts_as_commontable # dependent: :destroy # requires commontator 5.1
 
   validates :uuid, :title, :description, :owner, presence: true
-  validates :title, format: { with: /\A[^:\/\\]+\z/, message: 'must not contain a colon, forward-slash or back-slash (:/\\). Format your title differently or use an alternate glyph such as (꞉).' }
+  validates :title, format: { with: /\A[^:\/\\]+\z/, message: 'must not contain a colon, forward-slash or back-slash ( : / \\ ). Format your title differently or use an alternate glyph or full width variant such as (꞉／＼).' }
   validates :public, not_nil: true
   validates :uuid, uniqueness: { case_sensitive: false }
   validates :uuid, uuid: true

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -27,7 +27,7 @@ class Notebook < ActiveRecord::Base
   acts_as_commontable # dependent: :destroy # requires commontator 5.1
 
   validates :uuid, :title, :description, :owner, presence: true
-  validates :title, format: { with: /\A[^:\/\\]+\z/, message: 'must not contain a colon, forward-slash or back-slash (:/\\)' }
+  validates :title, format: { with: /\A[^:\/\\]+\z/, message: 'must not contain a colon, forward-slash or back-slash (:/\\). Format your title differently or use an alternate glyph such as (꞉).' }
   validates :public, not_nil: true
   validates :uuid, uniqueness: { case_sensitive: false }
   validates :uuid, uuid: true

--- a/app/views/errors/bad_change_request.slim
+++ b/app/views/errors/bad_change_request.slim
@@ -2,6 +2,8 @@ h1
   | Error 400
   span aria-hidden="true" #{":"}
 h2 Bad Request
-p ==exception.message.capitalize
+-error = exception.message.split('')
+-error.first.upcase!
+p ==error.join
 br
 ==image_tag("error_400_bad_request.jpg", class: "error-image", alt:"Picture of an astronaut asking a robot what his cellphone provider is because he has no service, but all of which is shown as a parody of a scene from \"Star Wars: Episode 6 - Return of the Jedi\".")

--- a/app/views/errors/bad_notebook.slim
+++ b/app/views/errors/bad_notebook.slim
@@ -1,6 +1,8 @@
 h1
   | Error Bad Notebook
   span aria-hidden="true" #{":"}
-p ==exception.message.capitalize
+-error = exception.message.split('')
+-error.first.upcase!
+p ==error.join
 br
 ==image_tag("error_bad_notebook.jpg", class: "error-image", alt:"Picture of an astronaut looking for his ship that is clearly visible to the viewer, but according to the astronaut and his technological instruments, the spaceship does not exist.")

--- a/app/views/errors/must_accept_terms.slim
+++ b/app/views/errors/must_accept_terms.slim
@@ -3,4 +3,4 @@ h1
   span aria-hidden="true" #{":"}
 h2 Must accept terms
 br
-==image_tag("error_must_accept_terms.jpg", class: "error-image", alt:"Picture of an astronaut aboard a spaceship throwing away a book titled \"Terms of Service\".")
+==image_tag("error_must_accept_terms.jpg", class: "error-image", alt:"Picture of an astronaut aboard a spaceship throwing away a book titled \"Terms of Service\" into a trash can.")


### PR DESCRIPTION
Closes #386 and #387 

Partially for legacy systems that have old notebooks with title with characters we have since deemed illegal so it better communicates with Jupyter. Whenever a user uploads a new version or accepts a change request any of the illegal characters :/\ will automatically switch to full width characters, with exception of the colon which is just a different Jupyter-friendly variant that barely looks different than the normal colon. 

In addition fixed an issue where padding was off for errors on home page and edited current error message for when a new upload has illegal characters to include the approved icons within the error message so they could copy/paste to save time.

## Changed Error Messages
![upload bad title error](https://user-images.githubusercontent.com/51969207/102121442-fb838a00-3e11-11eb-8a88-b2a5daecac75.PNG)
![title edit error](https://user-images.githubusercontent.com/51969207/102121443-fc1c2080-3e11-11eb-9fbd-76734c1082b3.PNG)

## When Fixed (no the prettiest but it at least lets them still preform the notebook update)
![full width characters](https://user-images.githubusercontent.com/51969207/102121441-fb838a00-3e11-11eb-87dc-7b3a080908db.PNG)
