### PR TITLE
External Resources: Added type of url to field so browser throws error accordingly

### DIFF
--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -417,7 +417,7 @@ div.modal.fade id="addResourceModal" aria-labelledby="addResourceHeader" aria-de
           div.form-group.has-feedback
             div.input-group
               span.input-group-addon.upload-addon #{GalleryConfig.external_resources_label} URL
-              input.form-control id="newResourceHref" type="text" name="resourceHref" value="" autocomplete="off" placeholder="URL for the #{GalleryConfig.external_resources_label}"
+              input.form-control id="newResourceHref" type="url" name="resourceHref" value="" autocomplete="off" placeholder="URL for the #{GalleryConfig.external_resources_label}"
             div.help-block.with-errors
           div.modal-footer
             button.btn.btn-danger data-dismiss="modal"


### PR DESCRIPTION
Closes #321. May not be enough information but will help get back on track the vast majority of people that would get stuck here. On both Firefox and Chrome browser generates an error there that looks as follows and tells them to use a valid url.

![browser generated error message](https://user-images.githubusercontent.com/51969207/102519895-14ce4580-4061-11eb-830c-50ff71d0d8ec.PNG)
