### PR TITLE
Fixes 404 when deleting Staged Notebook from /stages/uuid

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -717,6 +717,27 @@ $(document).ready(function(){
     return false;
     }
   });
+  $('#deleteStagedNotebook').on('click',function(){
+    bootbox.confirm("Are you sure you want to delete this staged notebook?", function(userResponse){
+      if (userResponse == true){
+        var url = $('#deleteStagedNotebook').prop('href');
+        bootboxPending('Deleting staged notebook!');
+        $.ajax({
+            url: url,
+            type: 'DELETE',
+            success: function(response){
+              bootbox.hideAll();
+              window.location=response.forward;
+            },
+            error: function(response){
+              bootbox.hideAll();
+              bootbox.alert('You had an error! ' + response.statusText);
+            }
+        });
+      }
+    })
+    return false;
+  });
 
   // Catch people uploading a notebook from the Jupyter client
   var target = document.location.hash.replace('#','');

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -71,7 +71,7 @@ class StagesController < ApplicationController
   def destroy
     @stage.destroy
     flash[:success] = "Staged notebook (edit) was destroyed successfully."
-    redirect_to(:back)
+    render json: {forward: stages_url}
   end
 
   # GET /stages/:uuid/preprocess

--- a/app/views/stages/index.slim
+++ b/app/views/stages/index.slim
@@ -27,7 +27,8 @@ div.content-container
               span.hidden aria-hidden="true" #{"]"}
             td
               span.hidden aria-hidden="true" #{"["}
-              a.delete-icon.tooltips href="#{stages_path + '/' + stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete" title="Destroy staged notebook"
+              /* a.delete-icon.tooltips id="deleteStagedNotebook" href="#{stages_path + '/' + stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete" title="Destroy staged notebook" */
+              a.delete-icon.tooltips id="deleteStagedNotebook" href="#{stage_path(stage.uuid)}" rel="nofollow" title="Destroy staged notebook"
                 i.glyphicon.glyphicon-trash
                 span.sr-only Destroy staged notebook
               span.hidden aria-hidden="true" #{"]"}

--- a/app/views/stages/index.slim
+++ b/app/views/stages/index.slim
@@ -27,7 +27,6 @@ div.content-container
               span.hidden aria-hidden="true" #{"]"}
             td
               span.hidden aria-hidden="true" #{"["}
-              /* a.delete-icon.tooltips id="deleteStagedNotebook" href="#{stages_path + '/' + stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete" title="Destroy staged notebook" */
               a.delete-icon.tooltips id="deleteStagedNotebook" href="#{stage_path(stage.uuid)}" rel="nofollow" title="Destroy staged notebook"
                 i.glyphicon.glyphicon-trash
                 span.sr-only Destroy staged notebook

--- a/app/views/stages/show.slim
+++ b/app/views/stages/show.slim
@@ -14,7 +14,6 @@ div.content-container id="stageView"
     div.button-container
       a href="/stages"
         button.btn.btn-primary Go Back
-      /* a id="deleteStagedNotebook" href="#{@stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete" */
       a id="deleteStagedNotebook" href="#{stage_path(@stage.uuid)}" rel="nofollow" title="Destroy staged notebook"
         button.btn.btn-danger Destroy
   br

--- a/app/views/stages/show.slim
+++ b/app/views/stages/show.slim
@@ -14,7 +14,8 @@ div.content-container id="stageView"
     div.button-container
       a href="/stages"
         button.btn.btn-primary Go Back
-      a href="#{@stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete"
+      /* a id="deleteStagedNotebook" href="#{@stage.uuid}" data-confirm="Are you sure?" rel="nofollow" data-method="delete" */
+      a id="deleteStagedNotebook" href="#{stage_path(@stage.uuid)}" rel="nofollow" title="Destroy staged notebook"
         button.btn.btn-danger Destroy
   br
   br


### PR DESCRIPTION
Fixed an issue where deleting a staged notebook from the stages/uuid would redirect to the page you're already on and 404. This solution now exactly mirrors that of the notebook delete. I have plans to redo all of the way we do confirmation dialogs in a more accessibility friendly way and way that matches our styling more but for now this at least gets them doing the same thing.

Closes #396 