### PR TITLE
Added pagination of code cells on notebooks to help load ridiculously large notebooks easier.

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1877,14 +1877,8 @@ p.description {
     position: relative;
 }
 #viewAsFullpage {
-    display: block;
-    margin-top: -1em;
-    @media all and (min-width: 800px) {
-        bottom: 1.5em;
-        display: inline-block;
-        margin-left: 1em;
-        position: absolute;
-    }
+    display: inline-block;
+    margin-top: -.5em;
 }
 
 /* ====================================== */

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -3292,7 +3292,9 @@ body.dark-theme {
             filter: invert(100%);
         }
     }
-    .sparkline {
+    .sparkline,
+    #viewAsFullPage,
+    #notebookCellPagination li.active span {
         filter: invert(100%);
     }
     #changeReqView {
@@ -3525,7 +3527,8 @@ body.ultra-dark-theme {
     &.path-video video,
     #navbarSearchBar .info-button,
     #expandableSearchDropdown,
-    .add-icon {
+    .add-icon,
+    #viewAsFullPage {
         filter: invert(100%);
     }
     .modal-header {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1872,6 +1872,21 @@ p.description {
     color: #fff;
 }
 
+/* === Notebook Pagination === */
+#notebookCellPagination {
+    position: relative;
+}
+#viewAsFullpage {
+    display: block;
+    margin-top: -1em;
+    @media all and (min-width: 800px) {
+        bottom: 1.5em;
+        display: inline-block;
+        margin-left: 1em;
+        position: absolute;
+    }
+}
+
 /* ====================================== */
 /* =========== PAGE SPECIFIC ============ */
 /* ====================================== */

--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -6,11 +6,14 @@ javascript:
 -all_health = notebook&.cell_health_status
 -code_cells ||= notebook&.code_cells
 -code_cell_number = 0
--require 'will_paginate/array'
--cells_paginated = jn['cells'].paginate(page: @page, per_page: 20)
--cells_paginated.each do |cell|
+-require "will_paginate/array"
+-if params[:view] == nil || params[:view].strip != "full"
+  -cells = jn["cells"].paginate(page: @page, per_page: 20)
+-else
+  -cells = jn["cells"]
+-cells.each do |cell|
   ruby:
-    if cell['cell_type'] == 'code' && !cell['source'].blank? && defined?(code_cells) && code_cells
+    if cell["cell_type"] == "code" && !cell["source"].blank? && defined?(code_cells) && code_cells
       code_cell = code_cells[code_cell_number]
       if code_cell != nil
         health_status = all_health&.dig(code_cell.id)
@@ -20,9 +23,13 @@ javascript:
       code_cell = nil
       health_status = nil
     end
-    source = [*cell['source']].join
+    source = [*cell["source"]].join
     next if source.size < 5 && source.strip.empty?
-  ==render partial: 'cell', locals: { jn: jn, cell: cell, code_cell: code_cell, health_status: health_status, source: source }
--if cells_paginated.respond_to? :total_pages
-  nav.center aria-label="Notebook contents pagination. View the other cells."
-    ==will_paginate cells_paginated, renderer: BootstrapPagination::Rails
+  ==render partial: "cell", locals: { jn: jn, cell: cell, code_cell: code_cell, health_status: health_status, source: source }
+-if cells.respond_to? :total_pages
+  nav.center id="notebookCellPagination" aria-label="Notebook contents pagination. View the other cells."
+    ==will_paginate cells, renderer: BootstrapPagination::Rails
+    a id="viewAsFullPage" href="#{notebook_path(@notebook) + '?view=full'}" title="View entire notebook instead" tabindex="-1"
+      button.btn.btn-primary
+        | View Full
+        span.sr-only #{" notebook instead"}

--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -29,8 +29,9 @@ javascript:
 -if cells.respond_to? :total_pages
   nav.center id="notebookCellPagination" aria-label="Notebook contents pagination. View the other cells."
     ==will_paginate cells, renderer: BootstrapPagination::Rails
-    div
-      a id="viewAsFullPage" href="#{notebook_path(@notebook) + '?view=full'}" title="View entire notebook instead" tabindex="-1"
-        button.btn.btn-primary
-          | View Full Notebook
-          span.sr-only #{" instead"}
+    -if jn["cells"].length >= 20
+      div
+        a id="viewAsFullPage" href="#{notebook_path(@notebook) + '?view=full'}" title="View entire notebook instead" tabindex="-1"
+          button.btn.btn-primary
+            | View Full Notebook
+            span.sr-only #{" instead"}

--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -24,5 +24,5 @@ javascript:
     next if source.size < 5 && source.strip.empty?
   ==render partial: 'cell', locals: { jn: jn, cell: cell, code_cell: code_cell, health_status: health_status, source: source }
 -if cells_paginated.respond_to? :total_pages
-  div.center
+  nav.center aria-label="Notebook contents pagination. View the other cells."
     ==will_paginate cells_paginated, renderer: BootstrapPagination::Rails

--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -1,12 +1,14 @@
 javascript:
   MathJax.Hub.Typeset();
 
-- notebook ||= nil
-- jn ||= notebook&.notebook
-- all_health = notebook&.cell_health_status
-- code_cells ||= notebook&.code_cells
-- code_cell_number = 0
-- jn['cells'].each do |cell|
+-notebook ||= nil
+-jn ||= notebook&.notebook
+-all_health = notebook&.cell_health_status
+-code_cells ||= notebook&.code_cells
+-code_cell_number = 0
+-require 'will_paginate/array'
+-cells_paginated = jn['cells'].paginate(page: @page, per_page: 20)
+-cells_paginated.each do |cell|
   ruby:
     if cell['cell_type'] == 'code' && !cell['source'].blank? && defined?(code_cells) && code_cells
       code_cell = code_cells[code_cell_number]
@@ -21,3 +23,6 @@ javascript:
     source = [*cell['source']].join
     next if source.size < 5 && source.strip.empty?
   ==render partial: 'cell', locals: { jn: jn, cell: cell, code_cell: code_cell, health_status: health_status, source: source }
+-if cells_paginated.respond_to? :total_pages
+  div.center
+    ==will_paginate cells_paginated, renderer: BootstrapPagination::Rails

--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -29,7 +29,8 @@ javascript:
 -if cells.respond_to? :total_pages
   nav.center id="notebookCellPagination" aria-label="Notebook contents pagination. View the other cells."
     ==will_paginate cells, renderer: BootstrapPagination::Rails
-    a id="viewAsFullPage" href="#{notebook_path(@notebook) + '?view=full'}" title="View entire notebook instead" tabindex="-1"
-      button.btn.btn-primary
-        | View Full
-        span.sr-only #{" notebook instead"}
+    div
+      a id="viewAsFullPage" href="#{notebook_path(@notebook) + '?view=full'}" title="View entire notebook instead" tabindex="-1"
+        button.btn.btn-primary
+          | View Full Notebook
+          span.sr-only #{" instead"}

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -76,7 +76,7 @@
     -else
       ==render partial: "notebook_listings"
     -if @notebooks.respond_to? :total_pages
-      nav.center
+      nav.center aria-label="Notebook pagination. View the other notebook listings."
         -if request.path != "/beta_home_notebooks"
           ==will_paginate @notebooks, renderer: BootstrapPagination::Rails
         -elsif @notebooks.length >= 20

--- a/app/views/application/_notebooks_home.slim
+++ b/app/views/application/_notebooks_home.slim
@@ -23,7 +23,7 @@ javascript:
 -else
   ==render partial: "notebook_listings"
   -if @notebooks.respond_to? :total_pages
-    nav.center
+    nav.center aria-label="Notebook pagination. View the other notebook listings."
       -if request.path != "/beta_home_notebooks" && request.path != "/home_notebooks"
         ==will_paginate @notebooks, renderer: BootstrapPagination::Rails
       -elsif @notebooks.length >= 20

--- a/app/views/users/index.slim
+++ b/app/views/users/index.slim
@@ -61,7 +61,7 @@ div.content-container
                 span.sr-only Destroy
   br
   -if users.respond_to? :total_pages
-    nav.center
+    nav.center aria-label="User pagination. View the other users."
       ==will_paginate users, renderer: BootstrapPagination::Rails
 
 javascript:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Run embedded solr.
   # Set this to false if you're running your own solr instance in dev
-  config.run_solr = true
+  config.run_solr = false
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Run embedded solr.
   # Set this to false if you're running your own solr instance in dev
-  config.run_solr = false
+  config.run_solr = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true


### PR DESCRIPTION
Closes #15, #399, and #401 

Added pagination after 20 notebook cells (code cells, text cells, etc). If this needs to be changed or moved up, it's an easy fix, but for testing given that the size of these 20 can vary use this as a baseline:

With breaking in 20 cell increments:
{SITE}/notebooks/86-recursion-examples is the minimum in terms of scrolling that would be required.
{SITE}/notebooks/148-visualization-earthquakes?page=4  is the maximum in terms of scrolling that I could find with these changes. Both load super easily.

Relative minimum:
![soft min scroll bar](https://user-images.githubusercontent.com/51969207/102805737-aacbde00-4389-11eb-9e6d-d55017418731.PNG)

Relative maximum:
![soft max scroll bar](https://user-images.githubusercontent.com/51969207/102805748-aef7fb80-4389-11eb-8446-7ab38bd58b93.PNG)