### PR TITLE
Code cell changes

### DIFF
--- a/app/assets/stylesheets/formatters.scss
+++ b/app/assets/stylesheets/formatters.scss
@@ -2,6 +2,8 @@
 /* generated using Pygments.css('.highlight') */
 .highlight {
     background: #f8f8f8;
+    white-space: pre-wrap;
+    word-break: break-all;
     .hll { background-color: #ffc }
     .c { color: #3e7c7c; font-style: italic } /* Comment */
     .err { border: 1px solid #f00 } /* Error */


### PR DESCRIPTION
Made it so horizontal scroll bars no longer appear:
![code cells with the changes](https://user-images.githubusercontent.com/51969207/102826231-41aa9180-43ae-11eb-96d8-650719d3bb61.PNG)

My attempt at editing the markdown syntax highlighter/markdown plugin to make it look like the current code block but with line numbers and the above issue of wrapped lines having same text indent applied to it was not successful. Best I could do with just a CSS hack for the record was as follows. Changes were not merged for obvious reasons.
![line numbers with css hacks purely](https://user-images.githubusercontent.com/51969207/102826420-8df5d180-43ae-11eb-9e7b-76300392bc52.PNG)

Will address these line number and other changes later, but for now leaving the code on here just to wrap them. If we want to turn the horizontal scrollbar functionality as something users can enable in their NBGallery preferences, just let me know, I think we need this out of he box though, although would be a lot better with line numbers or that margin fix.

Another thing to note, different version of a couple different gems will add a `<code>` tag between the pre.highlight and spans. I think this is needed eventually for screenreaders so users know a block is code, but not a requirement to date nor do I know if the experience would be different anyway.