### PR TITLE
NBGallery Search Engine Customizing

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -29,6 +29,10 @@ class StaticPagesController < ApplicationController
     render layout: false
   end
 
+  def opensearch
+    render layout: false
+  end
+
   def robots
     # Block crawl of test sites
     block_crawl =

--- a/app/views/application/_html_head.slim
+++ b/app/views/application/_html_head.slim
@@ -11,6 +11,7 @@ meta name="viewport" content="width=device-width, initial-scale=1.0"
 meta charset="UTF-8"
 -if defined? nofollow
   meta name="robots" content="nofollow"
+link rel="search" type="application/opensearchdescription+xml" title="#{GalleryConfig.site.name}" href="/opensearch.xml"
 title #{setup_browser_titles}
 
 -if defined? @notebook.description

--- a/app/views/static_pages/opensearch.erb
+++ b/app/views/static_pages/opensearch.erb
@@ -1,0 +1,8 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <InputEncoding>UTF-8</InputEncoding>
+  <ShortName><%=GalleryConfig.site.name%></ShortName>
+  <Description><%=GalleryConfig.site.name%> Search Engine</Description>
+  <Image width="16" height="16" type="image/icon"><%=favicon_link_tag "nb.ico"%></Image>
+  <Url type="text/html" template="<%=request.original_url[0...-15] + notebooks_path + "?q={searchTerms}"%>"></Url>
+  <moz:SearchForm><%=request.original_url[0...-15] + notebooks_path + "?q={searchTerms}"%></moz:SearchForm>
+</OpenSearchDescription>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do # rubocop: disable Metrics/BlockLength
   get 'faq' => 'static_pages#faq'
   get 'robots' => 'static_pages#robots'
   get 'video' => 'static_pages#video'
+  get 'opensearch' => 'static_pages#opensearch'
 
   # XXX DEPRECATED URLs for notebooks
   get 'notebook/:id' => 'notebooks#show' # compatibility with pre-rails site


### PR DESCRIPTION
Closes #385 or at least it should. Tested but couldn't get to work due to what I presume is a caching issue. I've triple checked to make sure it is all there and going to {SITE}/opensearch.xml loads it successfully. Also made sure it's exactly formatted like one of our coworkers made for another system (both the file and the meta tag). I think this is good just might not be registered because of the noindex nofollow or something. 

Anyway to know if it's working, when selecting from available search engines, should have the nbgallery icon and when in main url of browser and typing part of the url and then hitting tab once to complete it and then tab again to enable search, the string that it says it should be searching in should say "NBGallery" not the full url of the site.