### PR TITLE
Environments tweak: Increased colspan of the empty environments label when user has no environments.

### DIFF
--- a/app/views/environments/index.slim
+++ b/app/views/environments/index.slim
@@ -18,7 +18,7 @@ div.content-container
     tbody
       -if @environments.length <= 0
         tr
-          td.no-entries colspan="5" No Environments Found
+          td.no-entries colspan="6" No Environments Found
       -else
         -@environments.each do |environment|
           tr


### PR DESCRIPTION
Closes #428 

Fixes this: (super minor)
![environments makes colspan 6](https://user-images.githubusercontent.com/51969207/105104364-1768f400-5a80-11eb-91ca-913988c2ba93.PNG)
