### PR TITLE
Trigger notebook reindex by doing a notebook.save

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -307,6 +307,7 @@ class NotebooksController < ApplicationController
         request.base_url
       ).deliver_later
     end
+    @notebook.save
 
     # Attempt to share with non-members (extendable)
     unless non_member_emails.empty?


### PR DESCRIPTION
This forces solr to reload the notebook which fixes the search permission problem
Closes #383