### PR TITLE
Docker dev updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@ docker-run*
 
 /cache
 /change_requests
+/docker
 /data
 /integration
 /log

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ log/
 ## Docker
 /docker/data/
 /docker/log/
+/docker/bundle/
 
 ## tmp
 tmp/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,23 @@
+# This Dockerfile builds a command-line Ruby environment suitable
+# for working on nbgallery code.  Use in conjunction with the
+# docker-compose.yml to run solr and mysql.  Launch with the
+# docker-dev.sh script to set docker options and environment vars.
+
+FROM ruby:2.3
+
+RUN \
+  apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y --no-install-recommends \
+    mysql-client \
+    vim \
+    libfuzzy-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN \
+  echo "alias ll='ls -l'" >> ~/.bashrc && \
+  echo "cd /usr/src/nbgallery" >> ~/.bashrc
+
+EXPOSE 3000
+ENV RAILS_ENV=development
+CMD ["/bin/bash"]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   # Run embedded solr.
   # Set this to false if you're running your own solr instance in dev
   config.run_solr = true
+  config.run_solr = false if ENV['RUN_SOLR'] == 'false'
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/docker-dev.sh
+++ b/docker-dev.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This is intended to be used in conjunction with docker-compose.yml,
+# so mysql and solr server information should match what's used there.
+#
+# First, build the dev image if necessary:
+#   docker build -t nbgallery/dev -f Dockerfile.dev .
+#
+# Start mysql and solr but not the production nbgallery:
+#   docker-compose up -d mysql solr
+# 
+# Then run this script:
+#   ./docker-dev.sh
+#
+# The dev container should join the same network as mysql and solr.
+# Once inside the container, bundler is configured to install gems
+# into a mounted directory, so they will persist if you restart the
+# contaier.  Use bundler to install gems if the Gemfile has changed
+# or if this is the first time you've used the dev container:
+#   bundle install
+#
+# Run the rails server on port 3000:
+#   bundle exec rails server -b 0.0.0.0
+
+GALLERY__MYSQL__HOST=${GALLERY__MYSQL__HOST:=mysql}
+GALLERY__MYSQL__PORT=${GALLERY__MYSQL__PORT:=3306}
+GALLERY__MYSQL__USERNAME=${GALLERY__MYSQL__USERNAME:=root}
+GALLERY__MYSQL__PASSWORD=${GALLERY__MYSQL__PASSWORD:=xyz}
+GALLERY__MYSQL__DATABASE=${GALLERY__MYSQL__DATABASE:=gallery}
+GALLERY__SOLR__HOSTNAME=${GALLERY__SOLR__HOSTNAME:=solr}
+GALLERY__SOLR__PORT=${GALLERY__SOLR__PORT:=8983}
+
+docker run \
+  --rm \
+  -it \
+  --name nbgallery_dev \
+  --network nbgallery_default \
+  -p 3000:3000 \
+  -v `pwd`:/usr/src/nbgallery \
+  -v `pwd`/docker/log:/usr/src/nbgallery/log \
+  -v `pwd`/docker/data:/usr/src/nbgallery/data \
+  -v `pwd`/docker/bundle:/usr/src/nbgallery/bundle \
+  -e GALLERY__DIRECTORIES__DATA=/usr/src/nbgallery/data \
+  -e GALLERY__DIRECTORIES__CACHE=/usr/src/nbgallery/data/cache \
+  -e GALLERY__DIRECTORIES__CHANGE_REQUESTS=/usr/src/nbgallery/data/change_requests \
+  -e GALLERY__DIRECTORIES__STAGING=/usr/src/nbgallery/data/staging \
+  -e BUNDLE_PATH=/usr/src/nbgallery/bundle \
+  -e GALLERY__MYSQL__HOST=$GALLERY__MYSQL__HOST \
+  -e GALLERY__MYSQL__PORT=$GALLERY__MYSQL__PORT \
+  -e GALLERY__MYSQL__USERNAME=$GALLERY__MYSQL__USERNAME \
+  -e GALLERY__MYSQL__PASSWORD=$GALLERY__MYSQL__PASSWORD \
+  -e GALLERY__MYSQL__DATABASE=$GALLERY__MYSQL__DATABASE \
+  -e GALLERY__SOLR__HOSTNAME=$GALLERY__SOLR__HOSTNAME \
+  -e GALLERY__SOLR__PORT=$GALLERY__SOLR__PORT \
+  -e RAILS_SERVE_STATIC_FILES=true \
+  -e RUN_SOLR=false \
+  --env-file `pwd`/.env \
+  "$@" \
+  nbgallery/dev


### PR DESCRIPTION
Cleaned up the docker documentation after actually trying it from scratch for the first time.  The old manual setup notes are pretty useless at this point, so I deleted them.  Added some support to set up an environment for doing dev inside docker, with source mounted into the container.