### PR TITLE
WIP: Add Support for Timezones

### DIFF
--- a/app/views/application/_time_ago.slim
+++ b/app/views/application/_time_ago.slim
@@ -3,42 +3,6 @@
   time.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC")}"
     | #{time_ago_in_words(time)} ago
 -else
-  -timezone = user_pref.timezone
-  -adjusted_time = 0
-  -if timezone > 0
-    -hours = timezone.to_s[1...-2].to_i
-    -minutes = timezone.to_s.last(2).to_i
-    -adjusted_time = (time.to_time + hours.hours + minutes.minutes).to_datetime
-  -else
-    -hours = timezone.to_s[1...-2].to_i
-    -minutes = timezone.to_s.last(2).to_i
-    -adjusted_time = (time.to_time - hours.hours - minutes.minutes).to_datetime
-  -zone = timezone = timezone.to_s.insert(-3,":")
-  -case timezone
-  -when "-11:00"
-    -zone = "SST (UTC-11)"
-  -when "-10:00"
-    -zone = "HST (UTC-10)"
-  -when "-9:00"
-    -zone = "AKST (UTC-9)"
-  -when "-8:00"
-    -zone = "PST (UTC-8)"
-  -when "-7:00"
-    -zone = "MST (UTC-7)"
-  -when "-6:00"
-    -zone = "CST (UTC-6)"
-  -when "-5:00"
-    -zone = "EST (UTC-5)"
-  -when "-4:00"
-    -zone = "AST (UTC-4)"
-  -else
-    -if timezone.to_s.last(2) == "00"
-      -zone = timezone.to_s[0...-3]
-    -if zone[0] != "-"
-      -zone = "UTC+#{zone}"
-    -else
-      -zone = "UTC#{zone}"
-
-  -adjusted_time = "#{adjusted_time.strftime("%A, %B %d, %Y %H:%M UTC")[0..-4]} #{zone}"
-  time.tooltip-right.tooltipstered title="#{adjusted_time}"
+  -Time.zone = user_pref.timezone
+  time.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC").in_time_zone}"
     | #{time_ago_in_words(time)} ago

--- a/app/views/application/_time_ago.slim
+++ b/app/views/application/_time_ago.slim
@@ -1,18 +1,44 @@
--if @user_preference == nil || @user_preference.timezone == nil
-  time.tooltips.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC")}"
+-user_pref = UserPreference.where(user_id: @user.id).first
+-if user_pref == nil || user_pref.timezone == nil || user_pref.timezone == 0
+  time.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC")}"
     | #{time_ago_in_words(time)} ago
 -else
-  -timezone = @user_preference.timezone
-  -adjusted_time
+  -timezone = user_pref.timezone
+  -adjusted_time = 0
   -if timezone > 0
     -hours = timezone.to_s[1...-2].to_i
     -minutes = timezone.to_s.last(2).to_i
-    -adjusted_time = (time.to_time + hours(hours) + minutes(minutes)).to_datetime
-  -elsif timezone == 0
-    -timezone = "0:00"
+    -adjusted_time = (time.to_time + hours.hours + minutes.minutes).to_datetime
   -else
-    -hours = timezone.to_s[0...-2]
-    -minutes = timezone.to_s.last(2)
-    -adjusted_time = (time.to_time - hours(hours) - minutes(minutes)).to_datetime
-  time.tooltips.tooltip-right.tooltipstered title="#{adjusted_time.strftime("%A, %B %d, %Y %H:%M UTC")}"
+    -hours = timezone.to_s[1...-2].to_i
+    -minutes = timezone.to_s.last(2).to_i
+    -adjusted_time = (time.to_time - hours.hours - minutes.minutes).to_datetime
+  -zone = timezone = timezone.to_s.insert(-3,":")
+  -case timezone
+  -when "-11:00"
+    -zone = "SST (UTC-11)"
+  -when "-10:00"
+    -zone = "HST (UTC-10)"
+  -when "-9:00"
+    -zone = "AKST (UTC-9)"
+  -when "-8:00"
+    -zone = "PST (UTC-8)"
+  -when "-7:00"
+    -zone = "MST (UTC-7)"
+  -when "-6:00"
+    -zone = "CST (UTC-6)"
+  -when "-5:00"
+    -zone = "EST (UTC-5)"
+  -when "-4:00"
+    -zone = "AST (UTC-4)"
+  -else
+    -if timezone.to_s.last(2) == "00"
+      -zone = timezone.to_s[0...-3]
+    -if zone[0] != "-"
+      -zone = "UTC+#{zone}"
+    -else
+      -zone = "UTC#{zone}"
+
+  -adjusted_time = "#{adjusted_time.strftime("%A, %B %d, %Y %H:%M UTC")[0..-4]} #{zone}"
+  time.tooltip-right.tooltipstered title="#{adjusted_time}"
     | #{time_ago_in_words(time)} ago

--- a/app/views/application/_time_ago.slim
+++ b/app/views/application/_time_ago.slim
@@ -1,2 +1,18 @@
-time.tooltips.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC")}"
-  | #{time_ago_in_words(time)} ago
+-if @user_preference == nil || @user_preference.timezone == nil
+  time.tooltips.tooltip-right.tooltipstered title="#{time.strftime("%A, %B %d, %Y %H:%M UTC")}"
+    | #{time_ago_in_words(time)} ago
+-else
+  -timezone = @user_preference.timezone
+  -adjusted_time
+  -if timezone > 0
+    -hours = timezone.to_s[1...-2].to_i
+    -minutes = timezone.to_s.last(2).to_i
+    -adjusted_time = (time.to_time + hours(hours) + minutes(minutes)).to_datetime
+  -elsif timezone == 0
+    -timezone = "0:00"
+  -else
+    -hours = timezone.to_s[0...-2]
+    -minutes = timezone.to_s.last(2)
+    -adjusted_time = (time.to_time - hours(hours) - minutes(minutes)).to_datetime
+  time.tooltips.tooltip-right.tooltipstered title="#{adjusted_time.strftime("%A, %B %d, %Y %H:%M UTC")}"
+    | #{time_ago_in_words(time)} ago

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -80,21 +80,20 @@ div.content-container
           ' Enable Ultimate Accessibility Mode
           strong #{"[BETA]"}*/
 
-    /*h2 Timezone*/
-    /*p Will adjust all times on the site as you see them into what the respective time is for your timezone.*/
-    /*select name="timezone" id="timezone"
+    h2 Timezone
+    p Will adjust all times on the site as you see them into what the respective time is for your timezone.
+    select name="timezone" id="timezone"
       option value="-1200" (GMT -12:00) Eniwetok, Kwajalein
-      option value="-1100" (GMT -11:00) Midway Island, Samoa
-      option value="-1000" (GMT -10:00) Hawaii
-      option value="-950" (GMT -9:30) Taiohae
-      option value="-900" (GMT -9:00) Alaska
-      option value="-800" (GMT -8:00) Pacific Time (US &amp; Canada)
-      option value="-700" (GMT -7:00) Mountain Time (US &amp; Canada)
-      option value="-600" (GMT -6:00) Central Time (US &amp; Canada), Mexico City
-      option value="-500" (GMT -5:00) Eastern Time (US &amp; Canada), Bogota, Lima
-      option value="-450" (GMT -4:30) Caracas
-      option value="-400" (GMT -4:00) Atlantic Time (Canada), Caracas, La Paz
-      option value="-350" (GMT -3:30) Newfoundland
+      option value="-1100" (GMT -11:00/SST) Midway Island, Samoa
+      option value="-1000" (GMT -10:00/HST) Hawaii
+      option value="-930" (GMT -9:30) Taiohae
+      option value="-900" (GMT -9:00/AKST) Alaska
+      option value="-800" (GMT -8:00/PST) Pacific Time (US &amp; Canada)
+      option value="-700" (GMT -7:00/MST) Mountain Time (US &amp; Canada)
+      option value="-600" (GMT -6:00/CST) Central Time (US &amp; Canada), Mexico City
+      option value="-500" (GMT -5:00/EST) Eastern Time (US &amp; Canada), Bogota, Lima
+      option value="-400" (GMT -4:00/AST) Atlantic Time (Canada), Caracas, La Paz
+      option value="-330" (GMT -3:30) Newfoundland
       option value="-300" (GMT -3:00) Brazil, Buenos Aires, Georgetown
       option value="-200" (GMT -2:00) Mid-Atlantic
       option value="-100" (GMT -1:00) Azores, Cape Verde Islands
@@ -102,44 +101,60 @@ div.content-container
       option value="100" (GMT +1:00) Brussels, Copenhagen, Madrid, Paris
       option value="200" (GMT +2:00) Kaliningrad, South Africa
       option value="300" (GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg
-      option value="350" (GMT +3:30) Tehran
+      option value="330" (GMT +3:30) Tehran
       option value="400" (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
-      option value="450" (GMT +4:30) Kabul
+      option value="430" (GMT +4:30) Kabul
       option value="500" (GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent
-      option value="550" (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
-      option value="575" (GMT +5:45) Kathmandu, Pokhara
+      option value="530" (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
+      option value="545" (GMT +5:45) Kathmandu, Pokhara
       option value="600" (GMT +6:00) Almaty, Dhaka, Colombo
-      option value="650" (GMT +6:30) Yangon, Mandalay
+      option value="630" (GMT +6:30) Yangon, Mandalay
       option value="700" (GMT +7:00) Bangkok, Hanoi, Jakarta
       option value="800" (GMT +8:00) Beijing, Perth, Singapore, Hong Kong
-      option value="875" (GMT +8:45) Eucla
+      option value="845" (GMT +8:45) Eucla
       option value="900" (GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk
-      option value="950" (GMT +9:30) Adelaide, Darwin
+      option value="930" (GMT +9:30) Adelaide, Darwin
       option value="1000" (GMT +10:00) Eastern Australia, Guam, Vladivostok
       option value="1050" (GMT +10:30) Lord Howe Island
       option value="1100" (GMT +11:00) Magadan, Solomon Islands, New Caledonia
-      option value="1150" (GMT +11:30) Norfolk Island
+      option value="1130" (GMT +11:30) Norfolk Island
       option value="1200" (GMT +12:00) Auckland, Wellington, Fiji, Kamchatka
-      option value="1275" (GMT +12:45) Chatham Islands
-      option value="1300" (GMT +13:00) Apia, Nukualofa
-      option value="1400" (GMT +14:00) Line Islands, Tokelau*/
-    /*span
+      option value="1300" (GMT +13:00) Nukualofa
+      option value="1345" (GMT +13:45) Chatham Islands
+      option value="1400" (GMT +14:00) Line Islands, Tokelau, Apia
+    span
       strong id="currentTimezone"
         | Currently
         span aria-hidden="true" #{":"}
       -timezone = @user_preference.timezone
-      -if timezone > 0
-        -timezone = "+" + timezone.to_s.insert(-3,":")
-      -elsif timezone == 0
-        -timezone = "0:00"
+      -if timezone != nil
+        -if timezone > 0
+          -timezone = "+" + timezone.to_s.insert(-3,":")
+        -elsif timezone == 0
+          -timezone = "0:00"
+        -else
+          -timezone = timezone.to_s.insert(-3,":")
+        span
+          |  GMT #{timezone}
       -else
-        -timezone = timezone.to_s.insert(-3,":")
-      -if timezone[-2..-1] == "50"
-        -timezone[-2..-1] = "30"
-      -elsif timezone[-2..-1] == "75"
-        -timezone[-2..-1] = "45"
-      span
-        |  GMT #{timezone}*/
+        |  GMT
+      -case timezone
+      -when "-11:00"
+        |  (SST)
+      -when "-10:00"
+        |  (HST)
+      -when "-9:00"
+        |  (AKST)
+      -when "-8:00"
+        |  (PST)
+      -when "-7:00"
+        |  (MST)
+      -when "-6:00"
+        |  (CST)
+      -when "-5:00"
+        |  (EST)
+      -when "-4:00"
+        |  (AST)
 
     hr.divider.show style="display: none"
     div

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -83,45 +83,45 @@ div.content-container
     h2 Timezone
     p Will adjust all times on the site as you see them into what the respective time is for your timezone.
     select name="timezone" id="timezone"
-      option value="-1200" (GMT -12:00) Eniwetok, Kwajalein
-      option value="-1100" (GMT -11:00/SST) Midway Island, Samoa
-      option value="-1000" (GMT -10:00/HST) Hawaii
-      option value="-930" (GMT -9:30) Taiohae
-      option value="-900" (GMT -9:00/AKST) Alaska
-      option value="-800" (GMT -8:00/PST) Pacific Time (US &amp; Canada)
-      option value="-700" (GMT -7:00/MST) Mountain Time (US &amp; Canada)
-      option value="-600" (GMT -6:00/CST) Central Time (US &amp; Canada), Mexico City
-      option value="-500" (GMT -5:00/EST) Eastern Time (US &amp; Canada), Bogota, Lima
-      option value="-400" (GMT -4:00/AST) Atlantic Time (Canada), Caracas, La Paz
-      option value="-330" (GMT -3:30) Newfoundland
-      option value="-300" (GMT -3:00) Brazil, Buenos Aires, Georgetown
-      option value="-200" (GMT -2:00) Mid-Atlantic
-      option value="-100" (GMT -1:00) Azores, Cape Verde Islands
-      option value="0" selected="selected" (GMT) Western Europe Time, London, Lisbon, Casablanca
-      option value="100" (GMT +1:00) Brussels, Copenhagen, Madrid, Paris
-      option value="200" (GMT +2:00) Kaliningrad, South Africa
-      option value="300" (GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg
-      option value="330" (GMT +3:30) Tehran
-      option value="400" (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
-      option value="430" (GMT +4:30) Kabul
-      option value="500" (GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent
-      option value="530" (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
-      option value="545" (GMT +5:45) Kathmandu, Pokhara
-      option value="600" (GMT +6:00) Almaty, Dhaka, Colombo
-      option value="630" (GMT +6:30) Yangon, Mandalay
-      option value="700" (GMT +7:00) Bangkok, Hanoi, Jakarta
-      option value="800" (GMT +8:00) Beijing, Perth, Singapore, Hong Kong
-      option value="845" (GMT +8:45) Eucla
-      option value="900" (GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk
-      option value="930" (GMT +9:30) Adelaide, Darwin
-      option value="1000" (GMT +10:00) Eastern Australia, Guam, Vladivostok
-      option value="1050" (GMT +10:30) Lord Howe Island
-      option value="1100" (GMT +11:00) Magadan, Solomon Islands, New Caledonia
-      option value="1130" (GMT +11:30) Norfolk Island
-      option value="1200" (GMT +12:00) Auckland, Wellington, Fiji, Kamchatka
-      option value="1300" (GMT +13:00) Nukualofa
-      option value="1345" (GMT +13:45) Chatham Islands
-      option value="1400" (GMT +14:00) Line Islands, Tokelau, Apia
+      option value="-1200" selected=(@user_preference.timezone == -1200 ? "selected" : nil) (GMT -12:00) Eniwetok, Kwajalein
+      option value="-1100" selected=(@user_preference.timezone == -1100 ? "selected" : nil) (GMT -11:00/SST) Midway Island, Samoa
+      option value="-1000" selected=(@user_preference.timezone == -1000 ? "selected" : nil) (GMT -10:00/HST) Hawaii
+      option value="-930" selected=(@user_preference.timezone == -930 ? "selected" : nil) (GMT -9:30) Taiohae
+      option value="-900" selected=(@user_preference.timezone ==-900 ? "selected" : nil) (GMT -9:00/AKST) Alaska
+      option value="-800" selected=(@user_preference.timezone == -800 ? "selected" : nil) (GMT -8:00/PST) Pacific Time (US &amp; Canada)
+      option value="-700" selected=(@user_preference.timezone == -700 ? "selected" : nil) (GMT -7:00/MST) Mountain Time (US &amp; Canada)
+      option value="-600" selected=(@user_preference.timezone == -600 ? "selected" : nil) (GMT -6:00/CST) Central Time (US &amp; Canada), Mexico City
+      option value="-500" selected=(@user_preference.timezone == -500 ? "selected" : nil) (GMT -5:00/EST) Eastern Time (US &amp; Canada), Bogota, Lima
+      option value="-400" selected=(@user_preference.timezone == -400 ? "selected" : nil) (GMT -4:00/AST) Atlantic Time (Canada), Caracas, La Paz
+      option value="-330" selected=(@user_preference.timezone == -330 ? "selected" : nil) (GMT -3:30) Newfoundland
+      option value="-300" selected=(@user_preference.timezone == -300 ? "selected" : nil) (GMT -3:00) Brazil, Buenos Aires, Georgetown
+      option value="-200" selected=(@user_preference.timezone == -200 ? "selected" : nil) (GMT -2:00) Mid-Atlantic
+      option value="-100" selected=(@user_preference.timezone == -100 ? "selected" : nil) (GMT -1:00) Azores, Cape Verde Islands
+      option value="0" selected=(@user_preference.timezone == 0 ? "selected" : nil) (GMT) Western Europe Time, London, Lisbon, Casablanca
+      option value="100" selected=(@user_preference.timezone == 100 ? "selected" : nil) (GMT +1:00) Brussels, Copenhagen, Madrid, Paris
+      option value="200" selected=(@user_preference.timezone == 200 ? "selected" : nil) (GMT +2:00) Kaliningrad, South Africa
+      option value="300" selected=(@user_preference.timezone == 300 ? "selected" : nil) (GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg
+      option value="330" selected=(@user_preference.timezone == 330 ? "selected" : nil) (GMT +3:30) Tehran
+      option value="400" selected=(@user_preference.timezone == 400 ? "selected" : nil) (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
+      option value="430" selected=(@user_preference.timezone == 430 ? "selected" : nil) (GMT +4:30) Kabul
+      option value="500" selected=(@user_preference.timezone == 500 ? "selected" : nil) (GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent
+      option value="530" selected=(@user_preference.timezone == 530 ? "selected" : nil) (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
+      option value="545" selected=(@user_preference.timezone == 545 ? "selected" : nil) (GMT +5:45) Kathmandu, Pokhara
+      option value="600" selected=(@user_preference.timezone == 600 ? "selected" : nil) (GMT +6:00) Almaty, Dhaka, Colombo
+      option value="630" selected=(@user_preference.timezone == 630 ? "selected" : nil) (GMT +6:30) Yangon, Mandalay
+      option value="700" selected=(@user_preference.timezone == 700 ? "selected" : nil) (GMT +7:00) Bangkok, Hanoi, Jakarta
+      option value="800" selected=(@user_preference.timezone == 800 ? "selected" : nil) (GMT +8:00) Beijing, Perth, Singapore, Hong Kong
+      option value="845" selected=(@user_preference.timezone == 845 ? "selected" : nil) (GMT +8:45) Eucla
+      option value="900" selected=(@user_preference.timezone == 900 ? "selected" : nil) (GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk
+      option value="930" selected=(@user_preference.timezone == 930 ? "selected" : nil) (GMT +9:30) Adelaide, Darwin
+      option value="1000" selected=(@user_preference.timezone == 1000 ? "selected" : nil) (GMT +10:00) Eastern Australia, Guam, Vladivostok
+      option value="1030" selected=(@user_preference.timezone == 1030 ? "selected" : nil) (GMT +10:30) Lord Howe Island
+      option value="1100" selected=(@user_preference.timezone == 1100 ? "selected" : nil) (GMT +11:00) Magadan, Solomon Islands, New Caledonia
+      option value="1130" selected=(@user_preference.timezone == 1130 ? "selected" : nil) (GMT +11:30) Norfolk Island
+      option value="1200" selected=(@user_preference.timezone == 1200 ? "selected" : nil) (GMT +12:00) Auckland, Wellington, Fiji, Kamchatka
+      option value="1300" selected=(@user_preference.timezone == 1300 ? "selected" : nil) (GMT +13:00) Nukualofa
+      option value="1345" selected=(@user_preference.timezone == 1345 ? "selected" : nil) (GMT +13:45) Chatham Islands
+      option value="1400" selected=(@user_preference.timezone == 1400 ? "selected" : nil) (GMT +14:00) Line Islands, Tokelau, Apia
     span
       strong id="currentTimezone"
         | Currently
@@ -131,7 +131,7 @@ div.content-container
         -if timezone > 0
           -timezone = "+" + timezone.to_s.insert(-3,":")
         -elsif timezone == 0
-          -timezone = "0:00"
+          -timezone = ""
         -else
           -timezone = timezone.to_s.insert(-3,":")
         span

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -83,78 +83,59 @@ div.content-container
     h2 Timezone
     p Will adjust all times on the site as you see them into what the respective time is for your timezone.
     select name="timezone" id="timezone"
-      option value="-1200" selected=(@user_preference.timezone == -1200 ? "selected" : nil) (GMT -12:00) Eniwetok, Kwajalein
-      option value="-1100" selected=(@user_preference.timezone == -1100 ? "selected" : nil) (GMT -11:00/SST) Midway Island, Samoa
-      option value="-1000" selected=(@user_preference.timezone == -1000 ? "selected" : nil) (GMT -10:00/HST) Hawaii
-      option value="-930" selected=(@user_preference.timezone == -930 ? "selected" : nil) (GMT -9:30) Taiohae
-      option value="-900" selected=(@user_preference.timezone ==-900 ? "selected" : nil) (GMT -9:00/AKST) Alaska
-      option value="-800" selected=(@user_preference.timezone == -800 ? "selected" : nil) (GMT -8:00/PST) Pacific Time (US &amp; Canada)
-      option value="-700" selected=(@user_preference.timezone == -700 ? "selected" : nil) (GMT -7:00/MST) Mountain Time (US &amp; Canada)
-      option value="-600" selected=(@user_preference.timezone == -600 ? "selected" : nil) (GMT -6:00/CST) Central Time (US &amp; Canada), Mexico City
-      option value="-500" selected=(@user_preference.timezone == -500 ? "selected" : nil) (GMT -5:00/EST) Eastern Time (US &amp; Canada), Bogota, Lima
-      option value="-400" selected=(@user_preference.timezone == -400 ? "selected" : nil) (GMT -4:00/AST) Atlantic Time (Canada), Caracas, La Paz
-      option value="-330" selected=(@user_preference.timezone == -330 ? "selected" : nil) (GMT -3:30) Newfoundland
-      option value="-300" selected=(@user_preference.timezone == -300 ? "selected" : nil) (GMT -3:00) Brazil, Buenos Aires, Georgetown
-      option value="-200" selected=(@user_preference.timezone == -200 ? "selected" : nil) (GMT -2:00) Mid-Atlantic
-      option value="-100" selected=(@user_preference.timezone == -100 ? "selected" : nil) (GMT -1:00) Azores, Cape Verde Islands
-      option value="0" selected=(@user_preference.timezone == 0 ? "selected" : nil) (GMT) Western Europe Time, London, Lisbon, Casablanca
-      option value="100" selected=(@user_preference.timezone == 100 ? "selected" : nil) (GMT +1:00) Brussels, Copenhagen, Madrid, Paris
-      option value="200" selected=(@user_preference.timezone == 200 ? "selected" : nil) (GMT +2:00) Kaliningrad, South Africa
-      option value="300" selected=(@user_preference.timezone == 300 ? "selected" : nil) (GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg
-      option value="330" selected=(@user_preference.timezone == 330 ? "selected" : nil) (GMT +3:30) Tehran
-      option value="400" selected=(@user_preference.timezone == 400 ? "selected" : nil) (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
-      option value="430" selected=(@user_preference.timezone == 430 ? "selected" : nil) (GMT +4:30) Kabul
-      option value="500" selected=(@user_preference.timezone == 500 ? "selected" : nil) (GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent
-      option value="530" selected=(@user_preference.timezone == 530 ? "selected" : nil) (GMT +5:30) Bombay, Calcutta, Madras, New Delhi
-      option value="545" selected=(@user_preference.timezone == 545 ? "selected" : nil) (GMT +5:45) Kathmandu, Pokhara
-      option value="600" selected=(@user_preference.timezone == 600 ? "selected" : nil) (GMT +6:00) Almaty, Dhaka, Colombo
-      option value="630" selected=(@user_preference.timezone == 630 ? "selected" : nil) (GMT +6:30) Yangon, Mandalay
-      option value="700" selected=(@user_preference.timezone == 700 ? "selected" : nil) (GMT +7:00) Bangkok, Hanoi, Jakarta
-      option value="800" selected=(@user_preference.timezone == 800 ? "selected" : nil) (GMT +8:00) Beijing, Perth, Singapore, Hong Kong
-      option value="845" selected=(@user_preference.timezone == 845 ? "selected" : nil) (GMT +8:45) Eucla
-      option value="900" selected=(@user_preference.timezone == 900 ? "selected" : nil) (GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk
-      option value="930" selected=(@user_preference.timezone == 930 ? "selected" : nil) (GMT +9:30) Adelaide, Darwin
-      option value="1000" selected=(@user_preference.timezone == 1000 ? "selected" : nil) (GMT +10:00) Eastern Australia, Guam, Vladivostok
-      option value="1030" selected=(@user_preference.timezone == 1030 ? "selected" : nil) (GMT +10:30) Lord Howe Island
-      option value="1100" selected=(@user_preference.timezone == 1100 ? "selected" : nil) (GMT +11:00) Magadan, Solomon Islands, New Caledonia
-      option value="1130" selected=(@user_preference.timezone == 1130 ? "selected" : nil) (GMT +11:30) Norfolk Island
-      option value="1200" selected=(@user_preference.timezone == 1200 ? "selected" : nil) (GMT +12:00) Auckland, Wellington, Fiji, Kamchatka
-      option value="1300" selected=(@user_preference.timezone == 1300 ? "selected" : nil) (GMT +13:00) Nukualofa
-      option value="1345" selected=(@user_preference.timezone == 1345 ? "selected" : nil) (GMT +13:45) Chatham Islands
-      option value="1400" selected=(@user_preference.timezone == 1400 ? "selected" : nil) (GMT +14:00) Line Islands, Tokelau, Apia
+      option value="Etc/GMT+12" selected=(@user_preference.timezone == "Etc/GMT+12" ? "selected" : nil) (UTC -12:00) Baker Island, Eniwetok, Kwajalein (AoE)
+      option value="Midway Island" selected=(@user_preference.timezone == "Midway Island" ? "selected" : nil) (UTC -11:00) Midway Island, American Samoa (SST)
+      option value="Hawaii" selected=(@user_preference.timezone == "Hawaii" ? "selected" : nil) (UTC -10:00) Hawaii (HST)
+      option value="Alaska" selected=(@user_preference.timezone == "Alaska" ? "selected" : nil) (UTC -9:00/-8:00) Alaska (AKST/AKDT)
+      option value="Pacific Time (US & Canada)" selected=(@user_preference.timezone == "Pacific Time (US & Canada)" ? "selected" : nil) (UTC -8:00/-7:00) Pacific Time (US & Canada) (PST/PDT)
+      option value="Mountain Time (US & Canada)" selected=(@user_preference.timezone == "Mountain Time (US & Canada)" ? "selected" : nil) (UTC -7:00/-6:00) Mountain Time (US & Canada) (MST/MDT)
+      option value="Arizona" selected=(@user_preference.timezone == "Arizona" ? "selected" : nil) (UTC -7:00) Arizona Time (MST)
+      option value="Central Time (US & Canada)" selected=(@user_preference.timezone == "Central Time (US & Canada)" ? "selected" : nil) (UTC -6:00/-5:00) Central Time (US & Canada), Mexico City (CST/CDT)
+      option value="Eastern Time (US & Canada)" selected=(@user_preference.timezone == "Eastern Time (US & Canada)" ? "selected" : nil) (UTC -5:00/-4:00) Eastern Time (US & Canada), Bogota, Lima (EST/EDT)
+      option value="Atlantic Time (Canada)" selected=(@user_preference.timezone == "Atlantic Time (Canada)" ? "selected" : nil) (UTC -4:00/-3:00) Atlantic Time (Canada), Caracas, La Paz (AST/ADT)
+      option value="Georgetown" selected=(@user_preference.timezone == "Georgetown" ? "selected" : nil) (UTC -4:00) Georgetown, Guyana (GYT)
+      option value="Newfoundland" selected=(@user_preference.timezone == "Newfoundland" ? "selected" : nil) (UTC -3:30/-2:30) Newfoundland (NST/NDT)
+      option value="Brasilia" selected=(@user_preference.timezone == "Brasilia" ? "selected" : nil) (UTC -3:00) Brazil, Buenos Aires, Montevideo (BRT/ART/UYT)
+      option value="Greenland" selected=(@user_preference.timezone == "Greenland" ? "selected" : nil) (UTC -3:00/-2:00) West Greenland (WGT/WGST)
+      option value="Mid-Atlantic" selected=(@user_preference.timezone == "Mid-Atlantic" ? "selected" : nil) (UTC -2:00) Mid-Atlantic, South Georgia (GST)
+      option value="Azores" selected=(@user_preference.timezone == "Azores" ? "selected" : nil) (UTC -1:00/0:00) Azores Islands (AZOT/AZOST) East Greenland (EGT/EGST)
+      option value="Cape Verde Is." selected=(@user_preference.timezone == "Cape Verde Is." ? "selected" : nil) (UTC -1:00) Cape Verde Islands (CVT)
+      option value="London" selected=(@user_preference.timezone == "London" ? "selected" : nil) (UTC 0:00/+1:00) Western European Time (WET/WEST), United Kingdom (GMT/BST), Ireland (GMT/IST)
+      option value="Monrovia" selected=(@user_preference.timezone == "Monrovia" ? "selected" : nil) (UTC 0:00) Monrovia (GMT)
+      option value="Casablanca" selected=(@user_preference.timezone == "Casablanca" ? "selected" : nil) (UTC +1:00/0:00) Casablanca (WEST/WET)
+      option value="Paris" selected=(@user_preference.timezone == "Paris" ? "selected" : nil) (UTC +1:00/+2:00) Central European Time, Brussels, Copenhagen, Madrid, Paris (CET/CEST)
+      option value="West Central Africa" selected=(@user_preference.timezone == "West Central Africa" ? "selected" : nil) (UTC +1:00) West Africa Time, Central African Republic (WAT)
+      option value="Athens" selected=(@user_preference.timezone == "Athens" ? "selected" : nil) (UTC +2:00/+3:00) Eastern European Time, Bucharest, Kyiv, Athens (EET/EEST) Israel (IST/IDT)
+      option value="Cairo" selected=(@user_preference.timezone == "Cairo" ? "selected" : nil) (UTC +2:00) Kaliningrad, Cairo (EET), Central Africa Time (CAT)
+      option value="Moscow" selected=(@user_preference.timezone == "Moscow" ? "selected" : nil) (UTC +3:00) Moscow, Turkey, Arabia Standard Time, Eastern Africa Time (MSK/TRT/AST/EAT)
+      option value="Tehran" selected=(@user_preference.timezone == "Tehran" ? "selected" : nil) (UTC +3:30/+4:30) Tehran (IRST/IRDT)
+      option value="Muscat" selected=(@user_preference.timezone == "Muscat" ? "selected" : nil) (UTC +4:00) Gulf Standard Time, Azerbaijan, Armenia, Samara, Georgia (GST/AZT/AMT/SAMT/GET)
+      option value="Kabul" selected=(@user_preference.timezone == "Kabul" ? "selected" : nil) (UTC +4:30) Afghanistan (AFT)
+      option value="Ekaterinburg" selected=(@user_preference.timezone == "Ekaterinburg" ? "selected" : nil) (UTC +5:00) Yekaterinburg, Pakistan, Uzbekistan, Eastern Kazakhstan (YEKT/PKT/UZT/ORAT & AQTT)
+      option value="New Delhi" selected=(@user_preference.timezone == "New Delhi" ? "selected" : nil) (UTC +5:30) India (IST)
+      //Not working: option value="Kathmandu" selected=(@user_preference.timezone == "Kathmandu" ? "selected" : nil) (UTC +5:45) Nepal (NPT)
+      option value="Almaty" selected=(@user_preference.timezone == "Almaty" ? "selected" : nil) (UTC +6:00) Western Kazakhstan, Bangladesh, Novosibirsk (ALMT/BST/NOVT)
+      option value="Rangoon" selected=(@user_preference.timezone == "Rangoon" ? "selected" : nil) (UTC +6:30) Myanmar (MMT)
+      option value="Jakarta" selected=(@user_preference.timezone == "Jakarta" ? "selected" : nil) (UTC +7:00) Indochina Time, Western Indonesian Time, Krasnoyarsk (ICT/WIB/KRAT)
+      option value="Perth" selected=(@user_preference.timezone == "Perth" ? "selected" : nil) (UTC +8:00) Western Australia Standard Time, China, Singapore, Irkutsk (AWST/CST/SGT/IRKT)
+      //No Rails Support: option value="845" selected=(@user_preference.timezone == 845 ? "selected" : nil) (UTC +8:45) Australian Central Western Standard Time (ACWST)
+      option value="Tokyo" selected=(@user_preference.timezone == "Tokyo" ? "selected" : nil) (UTC +9:00) Tokyo, South Korea, Yakutsk (JST/KST/YAKT)
+      option value="Darwin" selected=(@user_preference.timezone == "Darwin" ? "selected" : nil) (UTC +9:30) Australian Central Standard Time (ACST)
+      option value="Adelaide" selected=(@user_preference.timezone == "Adelaide" ? "selected" : nil) (UTC +9:30/+10:30) South Australia (ACST/ACDT)
+      option value="1000" selected=(@user_preference.timezone == 1000 ? "selected" : nil) (UTC +10:00) Eastern Australia, Guam, Vladivostok
+      option value="1030" selected=(@user_preference.timezone == 1030 ? "selected" : nil) (UTC +10:30) Lord Howe Island
+      option value="1100" selected=(@user_preference.timezone == 1100 ? "selected" : nil) (UTC +11:00) Magadan, Solomon Islands, New Caledonia
+      option value="1130" selected=(@user_preference.timezone == 1130 ? "selected" : nil) (UTC +11:30) Norfolk Island
+      option value="1200" selected=(@user_preference.timezone == 1200 ? "selected" : nil) (UTC +12:00) Auckland, Wellington, Fiji, Kamchatka
+      option value="1300" selected=(@user_preference.timezone == 1300 ? "selected" : nil) (UTC +13:00) Nukualofa
+      option value="1345" selected=(@user_preference.timezone == 1345 ? "selected" : nil) (UTC +13:45) Chatham Islands
+      option value="1400" selected=(@user_preference.timezone == 1400 ? "selected" : nil) (UTC +14:00) Line Islands, Tokelau, Apia
     span
       strong id="currentTimezone"
         | Currently
         span aria-hidden="true" #{":"}
       -timezone = @user_preference.timezone
-      -if timezone != nil
-        -if timezone > 0
-          -timezone = "+" + timezone.to_s.insert(-3,":")
-        -elsif timezone == 0
-          -timezone = ""
-        -else
-          -timezone = timezone.to_s.insert(-3,":")
-        span
-          |  GMT #{timezone}
-      -else
-        |  GMT
-      -case timezone
-      -when "-11:00"
-        |  (SST)
-      -when "-10:00"
-        |  (HST)
-      -when "-9:00"
-        |  (AKST)
-      -when "-8:00"
-        |  (PST)
-      -when "-7:00"
-        |  (MST)
-      -when "-6:00"
-        |  (CST)
-      -when "-5:00"
-        |  (EST)
-      -when "-4:00"
-        |  (AST)
+
 
     hr.divider.show style="display: none"
     div

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -91,7 +91,7 @@ div.content-container
       option value="Mountain Time (US & Canada)" selected=(@user_preference.timezone == "Mountain Time (US & Canada)" ? "selected" : nil) (UTC -7:00/-6:00) Mountain Time (US & Canada) (MST/MDT)
       option value="Arizona" selected=(@user_preference.timezone == "Arizona" ? "selected" : nil) (UTC -7:00) Arizona Time (MST)
       option value="Central Time (US & Canada)" selected=(@user_preference.timezone == "Central Time (US & Canada)" ? "selected" : nil) (UTC -6:00/-5:00) Central Time (US & Canada), Mexico City (CST/CDT)
-      option value="Eastern Time (US & Canada)" selected=(@user_preference.timezone == "Eastern Time (US & Canada)" ? "selected" : nil) (UTC -5:00/-4:00) Eastern Time (US & Canada), Bogota, Lima (EST/EDT)
+      option value="Eastern Time (US & Canada)" selected=(@user_preference.timezone == "Eastern Time (US & Canada)" ? "selected" : nil) (UTC -5:00/-4:00) Eastern Time (US & Canada) (EST/EDT)
       option value="Atlantic Time (Canada)" selected=(@user_preference.timezone == "Atlantic Time (Canada)" ? "selected" : nil) (UTC -4:00/-3:00) Atlantic Time (Canada), Caracas, La Paz (AST/ADT)
       option value="Georgetown" selected=(@user_preference.timezone == "Georgetown" ? "selected" : nil) (UTC -4:00) Georgetown, Guyana (GYT)
       option value="Newfoundland" selected=(@user_preference.timezone == "Newfoundland" ? "selected" : nil) (UTC -3:30/-2:30) Newfoundland (NST/NDT)
@@ -103,12 +103,12 @@ div.content-container
       option value="London" selected=(@user_preference.timezone == "London" ? "selected" : nil) (UTC 0:00/+1:00) Western European Time (WET/WEST), United Kingdom (GMT/BST), Ireland (GMT/IST)
       option value="Monrovia" selected=(@user_preference.timezone == "Monrovia" ? "selected" : nil) (UTC 0:00) Monrovia (GMT)
       option value="Casablanca" selected=(@user_preference.timezone == "Casablanca" ? "selected" : nil) (UTC +1:00/0:00) Casablanca (WEST/WET)
-      option value="Paris" selected=(@user_preference.timezone == "Paris" ? "selected" : nil) (UTC +1:00/+2:00) Central European Time, Brussels, Copenhagen, Madrid, Paris (CET/CEST)
+      option value="Paris" selected=(@user_preference.timezone == "Paris" ? "selected" : nil) (UTC +1:00/+2:00) Central European Time, France, Spain (CET/CEST)
       option value="West Central Africa" selected=(@user_preference.timezone == "West Central Africa" ? "selected" : nil) (UTC +1:00) West Africa Time, Central African Republic (WAT)
-      option value="Athens" selected=(@user_preference.timezone == "Athens" ? "selected" : nil) (UTC +2:00/+3:00) Eastern European Time, Bucharest, Kyiv, Athens (EET/EEST) Israel (IST/IDT)
-      option value="Cairo" selected=(@user_preference.timezone == "Cairo" ? "selected" : nil) (UTC +2:00) Kaliningrad, Cairo (EET), Central Africa Time (CAT)
+      option value="Athens" selected=(@user_preference.timezone == "Athens" ? "selected" : nil) (UTC +2:00/+3:00) Eastern European Time, Greece, Finland (EET/EEST) Israel (IST/IDT)
+      option value="Cairo" selected=(@user_preference.timezone == "Cairo" ? "selected" : nil) (UTC +2:00) Kaliningrad, Egypt (EET), Central Africa Time (CAT)
       option value="Moscow" selected=(@user_preference.timezone == "Moscow" ? "selected" : nil) (UTC +3:00) Moscow, Turkey, Arabia Standard Time, Eastern Africa Time (MSK/TRT/AST/EAT)
-      option value="Tehran" selected=(@user_preference.timezone == "Tehran" ? "selected" : nil) (UTC +3:30/+4:30) Tehran (IRST/IRDT)
+      option value="Tehran" selected=(@user_preference.timezone == "Tehran" ? "selected" : nil) (UTC +3:30/+4:30) Iran (IRST/IRDT)
       option value="Muscat" selected=(@user_preference.timezone == "Muscat" ? "selected" : nil) (UTC +4:00) Gulf Standard Time, Azerbaijan, Armenia, Samara, Georgia (GST/AZT/AMT/SAMT/GET)
       option value="Kabul" selected=(@user_preference.timezone == "Kabul" ? "selected" : nil) (UTC +4:30) Afghanistan (AFT)
       option value="Ekaterinburg" selected=(@user_preference.timezone == "Ekaterinburg" ? "selected" : nil) (UTC +5:00) Yekaterinburg, Pakistan, Uzbekistan, Eastern Kazakhstan (YEKT/PKT/UZT/ORAT & AQTT)
@@ -121,15 +121,18 @@ div.content-container
       //No Rails Support: option value="845" selected=(@user_preference.timezone == 845 ? "selected" : nil) (UTC +8:45) Australian Central Western Standard Time (ACWST)
       option value="Tokyo" selected=(@user_preference.timezone == "Tokyo" ? "selected" : nil) (UTC +9:00) Tokyo, South Korea, Yakutsk (JST/KST/YAKT)
       option value="Darwin" selected=(@user_preference.timezone == "Darwin" ? "selected" : nil) (UTC +9:30) Australian Central Standard Time (ACST)
-      option value="Adelaide" selected=(@user_preference.timezone == "Adelaide" ? "selected" : nil) (UTC +9:30/+10:30) South Australia (ACST/ACDT)
-      option value="1000" selected=(@user_preference.timezone == 1000 ? "selected" : nil) (UTC +10:00) Eastern Australia, Guam, Vladivostok
-      option value="1030" selected=(@user_preference.timezone == 1030 ? "selected" : nil) (UTC +10:30) Lord Howe Island
-      option value="1100" selected=(@user_preference.timezone == 1100 ? "selected" : nil) (UTC +11:00) Magadan, Solomon Islands, New Caledonia
-      option value="1130" selected=(@user_preference.timezone == 1130 ? "selected" : nil) (UTC +11:30) Norfolk Island
-      option value="1200" selected=(@user_preference.timezone == 1200 ? "selected" : nil) (UTC +12:00) Auckland, Wellington, Fiji, Kamchatka
-      option value="1300" selected=(@user_preference.timezone == 1300 ? "selected" : nil) (UTC +13:00) Nukualofa
-      option value="1345" selected=(@user_preference.timezone == 1345 ? "selected" : nil) (UTC +13:45) Chatham Islands
-      option value="1400" selected=(@user_preference.timezone == 1400 ? "selected" : nil) (UTC +14:00) Line Islands, Tokelau, Apia
+      option value="Adelaide" selected=(@user_preference.timezone == "Adelaide" ? "selected" : nil) (UTC +10:30/+9:30) South Australia (ACST/ACDT)
+      option value="1000" selected=(@user_preference.timezone == 1000 ? "selected" : nil) (UTC +11:00/+10:00) Victoria & New South Wales Australia, Tasmania (AEDT/AEST)
+      option value="Guam" selected=(@user_preference.timezone == "Guam" ? "selected" : nil) (UTC +10:00) Queensland Australia, Guam, Vladivostok (AEST/GST/VLAT)
+      //No Rails Support: option value="1030" selected=(@user_preference.timezone == 1030 ? "selected" : nil) (UTC +10:30) Lord Howe Island
+      option value="Magadan" selected=(@user_preference.timezone == "Magadan" ? "selected" : nil) (UTC +11:00) Magadan, Solomon Islands, New Caledonia, Srednekolymsk (MAGT/SBT/NCT/SRET)
+      //No Rails Support: option value="1130" selected=(@user_preference.timezone == 1130 ? "selected" : nil) (UTC +11:30) Norfolk Island
+      option value="Kamchatka" selected=(@user_preference.timezone == "Kamchatka" ? "selected" : nil) (UTC +12:00) Kamchatka (PETT)
+      option value="Fiji" selected=(@user_preference.timezone == "Fiji" ? "selected" : nil) (UTC +13:00/+12:00) Fiji (FJT)
+      option value="Auckland" selected=(@user_preference.timezone == "Auckland" ? "selected" : nil) (UTC +13:00/+12:00) New Zealand (NZDT/NZST)
+      option value="Nuku'alofa" selected=(@user_preference.timezone == "Nuku'alofa" ? "selected" : nil) (UTC +13:00) Tonga, Tokelau (TOT/TKT)
+      option value="Chatham Is." selected=(@user_preference.timezone == "Chatham Is." ? "selected" : nil) (UTC +13:45/+12:45) Chatham Islands (CHADT/CHAST)
+      option value="Samoa" selected=(@user_preference.timezone == "Samoa" ? "selected" : nil) (UTC +14:00/+13:00) Samoa (WST)
     span
       strong id="currentTimezone"
         | Currently

--- a/db/migrate/20210209000001_change_timezone_to_be_string_in_user_preferences.rb
+++ b/db/migrate/20210209000001_change_timezone_to_be_string_in_user_preferences.rb
@@ -1,0 +1,9 @@
+class ChangeTimezoneToBeStringInUserPreferences < ActiveRecord::Migration
+  def up
+    change_column :user_preferences, :timezone, :string
+  end
+
+  def down
+    change_column :user_preferences, :timezone, :integer
+  end
+end


### PR DESCRIPTION
Closes #192 

In NBGallery Preferences can set timezone where all times when hovered across the rest of the product will now reflect said time  in relation to said timezone (in 24 hour clock). In addition will reveal timezone abbreviation for US and Canada timezones as well/also the UTC+/- number for reference. Could add more but a large number of them have conflicting names (vary country to country).

One problem I see is I use both GMT and UTC. I know they are used interchangeably in a casual environment but 
@mcrutch you have more experience with timezones so wanted to know what one I should make all of them say if we wanted to move to just using one for consistency... UTC or GMT? 

## How to set it
![timezones dropdown](https://user-images.githubusercontent.com/51969207/106644447-1e503600-6559-11eb-95d0-65407cb8edd5.PNG)
![timezones](https://user-images.githubusercontent.com/51969207/106644449-1e503600-6559-11eb-8fbf-0266b6003360.PNG)

## Negative timezones
![date revisions](https://user-images.githubusercontent.com/51969207/106644451-1e503600-6559-11eb-801a-8e1663e8eb39.PNG)

## Positive and non-abbreviation timezones
![positive timezones](https://user-images.githubusercontent.com/51969207/106644452-1e503600-6559-11eb-9e24-97297902f92e.PNG)

## Zero Time Zone (GMT/UTC)
Is just current experience