### PR TITLE
Code Catchup: Passed variable to custom fields

### DIFF
--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -165,7 +165,7 @@ div.modal.fade.notebookModalsSmall id="stageEdit" aria-labelledby="stageEditModa
             -else
               input.form-control type="text" id="editStagedName" name="staged" value="#{@notebook.title}" readonly=true
           span.glyphicon.form-control-feedback aria-hidden="true"
-        ==render partial: "custom_fields"
+        ==render partial: "custom_fields", locals: {is_upload: false}
         -if @notebook.revisions != nil
           div.form-group.has-feedback id="stageCommitMessage"
             div.input-group

--- a/app/views/modals/_upload.slim
+++ b/app/views/modals/_upload.slim
@@ -49,7 +49,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
               label
                 input type="checkbox" name="overwrite" value="true"
                 strong Overwrite this notebook
-        ==render partial: "custom_fields"
+        ==render partial: "custom_fields", locals: {is_upload: true}
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Description


### PR DESCRIPTION
Code Catchup: Passed variable to custom fields so user can differentiate them based on if it's coming from an upload modal vs upload new version or change request modal.