### PR TITLE
Enabled Deprecation to all owners

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -469,6 +469,11 @@ $(document).ready(function(){
   });
 
   // Disable/Enable hack for submit button. Remove once over to Rails 5, is default behavior in 5.
+  $('#freezeNotebook').on('change', function(){
+    if ($('.remove-deprecation-status').length) {
+      $('#deprecateNotebookSubmit').attr('disabled', false);
+    }
+  });
   if ($('#deprecateNotebookReasoning').value == null) {
     $('#deprecateNotebookSubmit').attr('disabled', true);
   }

--- a/app/views/modals/_notebook_actions.slim
+++ b/app/views/modals/_notebook_actions.slim
@@ -332,7 +332,7 @@ javascript:
     }
   });
 
--if @user.admin?
+-if @user.owner(@notebook)
   div.modal.fade id="deprecateNotebookModal" aria-labelledby="deprecateNotebookHeader" aria-describedby="deprecateNotebookDescription" role="dialog" style="display: none" tabindex="0"
     div.modal-dialog
       div.modal-content

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -133,13 +133,6 @@ div.content-container
                     | Delete notebook
                     span id="deleteConfirm"
                     span id="deleteWaiting"
-              -if @user.admin?
-                li.divider
-                li.dropdown-header.filter-item Admin Actions
-                li
-                  a.modal-activate href="#proposeReviewModal" id="proposeReview" data-toggle="modal"
-                    span.gear-dropdown-icon.fa.fa-file-code-o aria-hidden="true"
-                    | Propose for Review
                 li
                   a.modal-activate href="#deprecateNotebookModal" id="deprecateNotebookButton" data-toggle="modal"
                     -if @notebook.deprecated_notebook == nil
@@ -148,6 +141,13 @@ div.content-container
                     -else
                       span.gear-dropdown-icon.fa.fa-pencil-square-o aria-hidden="true"
                       | Edit Deprecation Status
+              -if @user.admin?
+                li.divider
+                li.dropdown-header.filter-item Admin Actions
+                li
+                  a.modal-activate href="#proposeReviewModal" id="proposeReview" data-toggle="modal"
+                    span.gear-dropdown-icon.fa.fa-file-code-o aria-hidden="true"
+                    | Propose for Review
         div.review-statuses
           p
             -open_reviews = FALSE


### PR DESCRIPTION
Closes #441

In addition fixes an issue where the deprecation submit button when editing the form does not become enabled (no disabled) after changing it from deprecated to disabled (the dropdown). Tested on Chrome and FF. Should be good to go now for all of those notebook owners.