### PR TITLE
Redesign-Search-Toggles

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2062,10 +2062,6 @@ body.page-notebook-search {
         }
     }
 }
-#filterDeprecatedForm,
-#filterPrivateNotebooksForm {
-    margin: 0;
-}
 
 /* === Search tooltip === */
 .search-tooltip {
@@ -2277,9 +2273,6 @@ div.search-filters-container {
         display: table-cell;
         vertical-align: top;
     }
-    .token {
-        margin-top: 1px;
-    }
 }
 .token .close,
 .tokenfield .token .close {
@@ -2353,6 +2346,20 @@ div.search-filters-container {
             margin-right: .3em;
         }
     }
+}
+.search-filters-super-container .tokenfield .token {
+    padding-top: .1em;
+    .close {
+        line-height: 1.2em;
+    }
+}
+#filterDeprecatedForm input,
+#filterPrivateNotebooksForm input {
+    margin: .1em .25em 0;
+}
+.search-filters-super-container .tokenfield .toggle-label {
+    padding-left: 4px;
+    vertical-align: top;
 }
 
 /* ===== Metric Pages (/notebooks/{ID}/metrics) ===== */

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -17,9 +17,10 @@
             -if @groups != nil && @groups.length > 0
               th Groups
             th Sort
-            th Show Deprecated
-            -if @user.admin
-              th Show Private
+            -if request.path.split("/")[1] == "notebooks" && params[:q] == nil
+              th Show Deprecated
+              -if @user.admin
+                th Show Private
         tbody
           tr
             -if @tags != nil && @tags.length > 0
@@ -62,26 +63,27 @@
                       input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
                     -else
                       input type="hidden" name==CGI.escape_html(key)
-            td
-              -unless @notebooks.empty? or defined? suggested_view
-                form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
-                  input id="deprecatedCheckbox" aria-label="Show Deprecated Notebooks" checked=(params[:show_deprecated] == "true"? "checked" : nil) name="show_deprecated" type="checkbox" value="true"
-                  -params.each do |key, value|
-                    -next if %w(id show_deprecated ascending splat captures controller action partial_name ajax).include?(key)
-                    -if value != nil
-                      input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
-                    -else
-                      input type="hidden" name==CGI.escape_html(key)
-            -if @user.admin && !@notebooks.empty?
+            -if request.path.split("/")[1] == "notebooks" && params[:q] == nil
               td
-                form id="filterPrivateNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
-                  input id="showPrivateNotebooks" aria-label="Show Private Notebooks" checked=(params[:use_admin] == "true"? "checked" : nil)  name="use_admin" type="checkbox" value="true"
-                  -params.each do |key, value|
-                    -next if %w(id use_admin ascending splat captures controller action partial_name ajax).include?(key)
-                    -if value != nil
-                      input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
-                    -else
-                      input type="hidden" name==CGI.escape_html(key)
+                -unless @notebooks.empty? or defined? suggested_view
+                  form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
+                    input id="deprecatedCheckbox" aria-label="Show Deprecated Notebooks" checked=(params[:show_deprecated] == "true"? "checked" : nil) name="show_deprecated" type="checkbox" value="true"
+                    -params.each do |key, value|
+                      -next if %w(id show_deprecated ascending splat captures controller action partial_name ajax).include?(key)
+                      -if value != nil
+                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                      -else
+                        input type="hidden" name==CGI.escape_html(key)
+              -if @user.admin && !@notebooks.empty?
+                td
+                  form id="filterPrivateNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
+                    input id="showPrivateNotebooks" aria-label="Show Private Notebooks" checked=(params[:use_admin] == "true"? "checked" : nil)  name="use_admin" type="checkbox" value="true"
+                    -params.each do |key, value|
+                      -next if %w(id use_admin ascending splat captures controller action partial_name ajax).include?(key)
+                      -if value != nil
+                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                      -else
+                        input type="hidden" name==CGI.escape_html(key)
 
     -if defined? group_view
       ==render partial: "notebook_listings", locals: { group_view: group_view }

--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -33,6 +33,12 @@ div class=(filters.length > 0 ? "super-container" : "super-container no-filter")
           input id="advancedSearch" name="q" type="hidden"
           input.searchFieldBox.form-control placeholder="Search" type="search" value="#{search.strip}" tabindex="0"
           input name="sort" type="hidden" value="score"
+          -params.each do |key, value|
+            -next if %w(id q sort ascending splat captures controller action partial_name ajax).include?(key)
+            -if value != nil
+              input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+            -else
+              input type="hidden" name==CGI.escape_html(key)
           a id="filterToggle" href="#" type="button"
             i class=(filters.length > 0 ? "fa fa-chevron-down spin": "fa fa-chevron-down") aria-hidden="true"
             span.add-filter-text aria-hidden="true" Advanced

--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -71,16 +71,38 @@ div class=(filters.length > 0 ? "super-container" : "super-container no-filter")
             button.btn.btn-primary id="filterFormSubmit" Add Filter
             button.btn.btn-success id="filterFormSubmitAndSearch" type="submit" Search
       div.search-filters-super-container
-        div.search-filters-container style=(filters.length == 0? "display: none" : "")
+        div.search-filters-container
           p.search-filters
             strong
               | Added Filters
               span aria-hidden="true" #{":"}
             div.tokenfield
+              -unless @notebooks.empty? or defined? suggested_view
+                div.token
+                  form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
+                    span.toggle-label Show Deprecated
+                    input id="deprecatedCheckbox" aria-label="Show Deprecated Notebooks" checked=(params[:show_deprecated] == "true"? "checked" : nil) name="show_deprecated" type="checkbox" value="true"
+                    -params.each do |key, value|
+                      -next if %w(id show_deprecated ascending splat captures controller action partial_name ajax).include?(key)
+                      -if value != nil
+                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                      -else
+                        input type="hidden" name==CGI.escape_html(key)
+              -if @user.admin && !@notebooks.empty?
+                div.token
+                  form id="filterPrivateNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
+                    span.toggle-label Show Private
+                    input id="showPrivateNotebooks" aria-label="Show Private Notebooks" checked=(params[:use_admin] == "true"? "checked" : nil)  name="use_admin" type="checkbox" value="true"
+                    -params.each do |key, value|
+                      -next if %w(id use_admin ascending splat captures controller action partial_name ajax).include?(key)
+                      -if value != nil
+                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                      -else
+                        input type="hidden" name==CGI.escape_html(key)
               -filters.each do |filter|
                 div.token
                   span.token-label ==filter
                   span.sr-only #{" "}
-                  a.close.tooltips href="#" tab-index="-1" title="Delete search filter"
+                  a.close.tooltips.tooltipstered href="#" tab-index="-1" title="Delete search filter"
                     span aria-hidden="true" &times;
                     span.sr-only Delete search filter of "#{filter}"


### PR DESCRIPTION
On search pages now have the private and show deprecated toggles appear under the filters section.

Closes #453 

## With Advanced Search not toggled
![search not expanded](https://user-images.githubusercontent.com/51969207/107676356-0b2f1b80-6c67-11eb-880b-48d681967f75.PNG)

## With Advanced Search toggled
![advanced search expanded](https://user-images.githubusercontent.com/51969207/107676355-0b2f1b80-6c67-11eb-94ee-6845bd6295f5.PNG)

## Firefox
![firefox for search](https://user-images.githubusercontent.com/51969207/107676353-0a968500-6c67-11eb-9616-7fe40d696b30.PNG)

## Low Vision
![400% for low vision on search](https://user-images.githubusercontent.com/51969207/107676354-0a968500-6c67-11eb-9079-1fdc22a39d10.PNG)