### PR TITLE
Allow GET /tags/* in CORS

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,6 +78,7 @@ module JupyterGallery
         resource '/stages', headers: :any, methods: %i[post options], credentials: true
         resource '/integration/*', headers: :any, methods: %i[get], credentials: true
         resource '/executions', headers: :any, methods: %i[post], credentials: true
+        resource '/tags/*', headers: :any, methods: %i[get], credentials: true
       end
       GalleryConfig.search&.allowed_cors&.each do |search_cors|
         allow do
@@ -103,7 +104,7 @@ module JupyterGallery
     if GalleryConfig.disable_ssl_verify
       OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
     end
-    
+
     config.encoding = 'utf-8'
 
     # Set up extension system


### PR DESCRIPTION
closes #473 

@jeffyjefflabs and @mcrutch  I don't know to test this so can you let me know if this looks right or if it needs to have a different origin other than (`origins {|_source, _env| true}` that most of the other CORS policies have).