### PR TITLE
Revision History table fix for metadata cells hanging over edge.

### DIFF
--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -33,13 +33,10 @@ div.content-container id="revisionsPage"
                 | Unknown
             td ==rev.revtype
             td ==render partial: "time_ago", locals: {time: rev.created_at}
-            -if rev.revtype == "metadata"
-              td.empty-cell
-              td.empty-cell
-              td.empty-cell
-              td.empty-cell
-            -else
-              -if @notebook.reviews.length > 0
+            -if @notebook.reviews.length > 0
+              -if rev.revtype == "metadata"
+                td.empty-cell
+              -else
                 td
                   div.review-icon-container
                     -if total_reviews_left > 0 #for efficiency
@@ -72,8 +69,14 @@ div.content-container id="revisionsPage"
                                     i.fa.fa-rocket.tooltips aria-hidden="true" title='Type: #{GalleryConfig.reviews.functional.label}, Status: approved'
                                     span.sr-only #{GalleryConfig.reviews.functional.label} review has been approved
                                 span.hidden aria-hidden="true" #{"]"}
+            -if rev.revtype == "metadata"
+              td.empty-cell
+            -else
               td ==link_to_revision(rev)
-              -if display_compare
+            -if display_compare
+              -if rev.revtype == "metadata"
+                td.empty-cell
+              -else
                 td
                   -if previous && rev.commit_id != previous.commit_id
                     -most_recent_comparison_path = diff_notebook_revision_path(@notebook, previous, revision: rev.commit_id)
@@ -82,6 +85,9 @@ div.content-container id="revisionsPage"
                       i.fa.fa-files-o
                       span.sr-only Notebook version diff side-by-side comparison highlighting changes made since previous version
                     span.hidden aria-hidden="true" #{"]"}
+            -if rev.revtype == "metadata"
+              td.empty-cell
+            -else
               td.commit-message-cell
                 div.mouseoveredit
                   -if rev.commit_message != nil


### PR DESCRIPTION
Don't have a notebook with 2 rows (one as create and one as metadata). But tested for ones missing reviews and one with all the things. My code should work with what happens when no reviews AND no compare current/preview column exists, just checked every notebook in database with metadata that has it and tried adding my own manipulating the metadata field of notebooks and couldn't get it to upload as a "metadata" change.

Notebook ID's to checkout for testing `ID: 537` for what all columns looks like. `ID: 464` for missing reviews column.

PS. For the record I dislike how many conditionals are in here but these changes do fix the problem.