### PR TITLE
Show search filter toggles on empty notebook searches.

### DIFF
--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -83,18 +83,17 @@ div class=(filters.length > 0 ? "super-container" : "super-container no-filter")
               | Added Filters
               span aria-hidden="true" #{":"}
             div.tokenfield
-              -unless @notebooks.empty? or defined? suggested_view
-                div.token
-                  form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
-                    span.toggle-label Show Deprecated
-                    input id="deprecatedCheckbox" aria-label="Show Deprecated Notebooks" checked=(params[:show_deprecated] == "true"? "checked" : nil) name="show_deprecated" type="checkbox" value="true"
-                    -params.each do |key, value|
-                      -next if %w(id show_deprecated ascending splat captures controller action partial_name ajax).include?(key)
-                      -if value != nil
-                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
-                      -else
-                        input type="hidden" name==CGI.escape_html(key)
-              -if @user.admin && !@notebooks.empty?
+              div.token
+                form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
+                  span.toggle-label Show Deprecated
+                  input id="deprecatedCheckbox" aria-label="Show Deprecated Notebooks" checked=(params[:show_deprecated] == "true"? "checked" : nil) name="show_deprecated" type="checkbox" value="true"
+                  -params.each do |key, value|
+                    -next if %w(id show_deprecated ascending splat captures controller action partial_name ajax).include?(key)
+                    -if value != nil
+                      input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                    -else
+                      input type="hidden" name==CGI.escape_html(key)
+              -if @user.admin
                 div.token
                   form id="filterPrivateNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
                     span.toggle-label Show Private


### PR DESCRIPTION
## Repro Steps
1. Before checking out this branch, search for "testgerergerger", verify there is no way to see deprecated or private notebooks when searching for that.
2. Checkout branch and search for it. Verify you see the toggleable filters.
3. Enable bother and verify you see the notebook in the search results.

Closes #487

## Screenshots
![search fields on load](https://user-images.githubusercontent.com/51969207/110139029-97cd8500-7da0-11eb-9ce8-2b7aa922d392.PNG)

![search fields working](https://user-images.githubusercontent.com/51969207/110139028-97cd8500-7da0-11eb-9665-d2ff1243a657.PNG)