### PR TITLE
Fixed Code Cell Numbering for Pagination

### DIFF
--- a/app/views/application/_notebook.slim
+++ b/app/views/application/_notebook.slim
@@ -13,6 +13,31 @@ javascript:
   -cells = jn["cells"].paginate(page: @page, per_page: 20)
 -else
   -cells = jn["cells"]
+
+// Calculate what each page's code cell id and health should start at
+ruby:
+  page_cell_starts = [0]
+  if (cells.respond_to? :total_pages)
+    jn["cells"].each_with_index do |cell, index|
+      if index % 20 == 0 && index != 0
+        if cell["cell_type"] == "code" && !cell["source"].blank? && defined?(code_cells) && code_cells
+          code_cell_number += 1
+          page_cell_starts.push(code_cell_number)
+        else
+          page_cell_starts.push(code_cell_number)
+        end
+      elsif cell["cell_type"] == "code" && !cell["source"].blank? && defined?(code_cells) && code_cells
+        code_cell_number += 1
+      end
+    end
+  end
+  code_cell_number = 0
+
+// Designate starting code_cell_number based on page parameter
+-if (cells.respond_to? :total_pages) && params[:page] && params[:page].present?
+  -code_cell_number = page_cell_starts[params[:page].to_i - 1]
+
+// Populate properly-linked code health icons
 -cells.each do |cell|
   ruby:
     if cell["cell_type"] == "code" && !cell["source"].blank? && defined?(code_cells) && code_cells
@@ -28,6 +53,8 @@ javascript:
     source = [*cell["source"]].join
     next if source.size < 5 && source.strip.empty?
   ==render partial: "cell", locals: { jn: jn, cell: cell, code_cell: code_cell, health_status: health_status, source: source }
+
+// Generate pagination bar
 -if cells.respond_to? :total_pages
   nav.center id="notebookCellPagination" aria-label="Notebook contents pagination. View the other cells."
     ==will_paginate cells, renderer: BootstrapPagination::Rails


### PR DESCRIPTION
Closes #516 

Test by going to /notebooks/693-45-mixed-cell-notebook

Verify the link of the health icons consistently goes up based on what page and what cell you are looking at. Although we paginate after 20 cells, we paginate code cells based on only cells that are code ones, not "raw" or "markdown" cells. 