### PR TITLE
Fixing User Summary

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,14 +72,14 @@ class UsersController < ApplicationController
   def summary
     min_date = params[:min_date]
     max_date = params[:max_date]
-    @counts = @viewed_user.notebook_action_counts(min_date: min_date, max_date: max_date)
-    @counts[:id] = @user.id
     respond_to do |format|
-      if max_date != nil && max_date != nil && max_date < min_date
+      if !max_date.blank? && !min_date.blank? && max_date < min_date
         flash[:error] = "Your 'End Date' must occur after your 'Start Date.'"
         redirect_to(:back)
         break
       end
+      @counts = @viewed_user.notebook_action_counts(min_date: min_date, max_date: max_date)
+      @counts[:id] = @user.id
       format.html
       format.json do
         render json: @counts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -468,7 +468,6 @@ class User < ActiveRecord::Base
     max_date = options[:max_date]
     actions = action_counts(min_date, max_date)
     reviews = review_counts(min_date, max_date)
-
     # IDs of user's public created notebooks, ignoring date range
     all_public_ids = notebooks_created.where(public: true).pluck(:id)
     # User's public created notebooks, within the date range
@@ -606,9 +605,13 @@ class User < ActiveRecord::Base
 
   private
 
+  def convert_to_iso8601(date)
+    Date.strptime(date, "%m/%d/%Y").iso8601
+  end
+
   def apply_date_range(relation, min_date=nil, max_date=nil, field='updated_at')
-    relation = relation.where("#{field} >= ?", min_date) if min_date
-    relation = relation.where("#{field} <= ?", max_date) if max_date
+    relation = relation.where("#{field} >= ?", convert_to_iso8601(min_date)) if !min_date.blank?
+    relation = relation.where("#{field} <= ?", convert_to_iso8601(max_date)) if !max_date.blank?
     relation
   end
 end

--- a/app/views/users/summary.slim
+++ b/app/views/users/summary.slim
@@ -2,7 +2,12 @@ javascript:
   $(document).ready(function(){
       $('#summaryTimeStart').bootstrapDatepicker({autoclose:true});
       $('#summaryTimeEnd').bootstrapDatepicker({autoclose:true});
+      $('#summaryAllTimeButton').click(function(e){
+        $('#summaryTimeStart').val("");
+        $('#summaryTimeEnd').val("");
+      });
   });
+
 
 div.content-container
   div.return
@@ -54,15 +59,15 @@ div.content-container
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Start Date
-            input.form-control.tooltips type="text" name="min_date" placeholder="12/31/1999" title="Start Date" required=true id="summaryTimeStart" value="#{params[:min_date]}"
+            input.form-control.tooltips type="text" name="min_date" placeholder="12/31/1999" title="Start Date" required=false id="summaryTimeStart" value="#{params[:min_date]}"
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon End Date
-            input.form-control.tooltips type="text" name="max_date" placeholder="12/31/2099" title="End Date" required=true id="summaryTimeEnd" value="#{params[:max_date]}"
+            input.form-control.tooltips type="text" name="max_date" placeholder="12/31/2099" title="End Date" required=false id="summaryTimeEnd" value="#{params[:max_date]}"
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.button-container
           a
             button.btn.btn-success type="submit" Submit
-          a href="#{summary_user_path(@viewed_user)}"
+          a href="#{summary_user_path(@viewed_user)}" id="summaryAllTimeButton"
             button.btn.btn-primary All Time


### PR DESCRIPTION
Closes #575
Fixes All Time button to work
Allows start and or end date to be empty both in support of All Time and also to allow the user to have an open ended date range
Converts date/times to iso8601 to ensure queries are successful