### PR TITLE
Search Pagination Fix

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -350,8 +350,12 @@ $(document).ready(function(){
   $('body.page-notebook-search form#bigSearchBar').on('submit',function(){
     $('.search-filters-container .token-label').prepend(' ');
     var search_filters = $('.search-filters-container .token-label');
-    var search_query = $('#bigSearchBar input.searchFieldBox').val() + search_filters.text();
+    var search_input = $('#bigSearchBar input.searchFieldBox');
+    var search_query = search_input.val() + search_filters.text();
     $('#advancedSearch').val(search_query);
+    if (search_input.val() != search_input.data('oldvalue')){
+      $('input[name="page"]').val(1);
+    }
   });
   $('#filterFormType').change(function() {
     $('#emptyfilterInclusionContainer').css("display","none");

--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -31,7 +31,7 @@ div class=(filters.length > 0 ? "super-container" : "super-container no-filter")
       form id="bigSearchBar" action="#{notebooks_path}" role="search"
         div.form-group
           input id="advancedSearch" name="q" type="hidden"
-          input.searchFieldBox.form-control placeholder="Search" type="search" value="#{search.strip}" tabindex="0"
+          input.searchFieldBox.form-control placeholder="Search" type="search" data-oldvalue="#{search.strip}" value="#{search.strip}" tabindex="0"
           input name="sort" type="hidden" value="score"
           -params.each do |key, value|
             -next if %w(id q sort ascending splat captures controller action partial_name ajax).include?(key)


### PR DESCRIPTION
Closes #624 

Changing search filters or toggling deprecated or private notebooks only still does not refresh what page of results you are (which I assume is by design), BUT changing the word(s) in the search box does cause pagination to go back to first page every page.