### PR TITLE
More Theme Fixes

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2144,7 +2144,7 @@ body.page-home #bigSearchBar {
     }
     .tab a {
         border-bottom: .4em solid $primary-border-color;
-        color: $intermediate-icon-color;
+        color: $lighter-icon-color;
         cursor: pointer;
         display: block;
         font-size: 14pt;
@@ -3807,6 +3807,43 @@ body.ultra-dark-theme {
     tr td:first-child:before {
         box-shadow: 0 0 3px #bbb !important;
         filter: invert(100%);
+    }
+
+    .modal .form-group {
+        &.has-error,
+        &.has-success {
+            filter: invert(100%);
+        }
+        .form-control {
+            color: #999;
+        }
+        .token {
+            color: #555;
+            filter: invert(100%);
+        }
+        &.has-error,
+        &.has-error .help-block,
+        &.has-error .input-group-addon,
+        .remaining-characters-warning {
+            color: #d05451;
+        }
+        &.has-error .form-control,
+        &.has-error .input-group-addon {
+            background-color: #230707;
+            border: 1px solid #d05451;
+        }
+        &.has-success,
+        &.has-success .input-group-addon {
+            color: #4c964d;
+        }
+        &.has-success .form-control,
+        &.has-success .input-group-addon {
+            background-color: #092307;
+            border: 1px solid #4c964d;
+        }
+    }
+    .modal .select-dropdown .close {
+        filter: invert(1);
     }
 }
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -23,7 +23,7 @@ $text-color: #000;
 $header-color: #333;
 $darker-icon-color: #333;
 $intermediate-icon-color: #666;
-$lighter-icon-color: #777;
+$lighter-icon-color: #757575;
 $error-text-color: #f00;
 $error-text-color-darker: #da0000;
 $text-weight: 400;
@@ -65,7 +65,7 @@ $site-footer-background-color: $secondary-background;
 $dark-theme-background-color: #333;
 $dark-theme-background-color-darker: #111;
 $dark-theme-main-link-color: #fd711f;
-$dark-theme-main-link-darker: darken($dark-theme-main-link-color, 15%);
+$dark-theme-main-link-darker: #bf4702;
 
 /* ===== Main Color Alterations ===== */
 $primary-color-lightened: lighten($primary-color, 35%);


### PR DESCRIPTION
Closes #617 

- Lastly made the ultra dark themes more user friendly. Green, not purple now means success. Red, not teal, now means error. Screenshot shown below.
- For ultra dark on home page, made inactive tab color lighter
- For dark theme on tables, made link color slightly darker

![Ultra dark theme modal example](https://user-images.githubusercontent.com/51969207/146049831-6e273a94-f4a5-4792-9725-1854585d691c.PNG)
