### PR TITLE
Consistent and accessibility-support styling of notebook titles in listings

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1055,10 +1055,6 @@ body.notebook-deprecated {
         font-family: $secondary-font-family;
         font-size: 150%;
         word-break: break-word;
-        &:hover {
-            color: #808080;
-            text-decoration: none;
-        }
     }
     .verified-icon {
         margin: -.3em 0 0 .2em;


### PR DESCRIPTION
Closes #409 

By removing the styles includes, all notebook listings on all themes have an underline when hovered or focused. The color on hover was a rogue color anyway as it wasn't a variable.