### PR TITLE
Quick Copy Buttons on Metric pages for all User Emails

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -745,4 +745,21 @@ $(document).ready(function(){
       element.style.cssText = 'height:' + value + 'px';
     },0);
   }
+
+  /* ===================================== */
+  /* ========= Copy to Clipboard ========= */
+  /* ===================================== */
+  $('.copy-to-clipboard').click(function() {
+    if (navigator.clipboard && window.isSecureContext){
+      navigator.clipboard.writeText($(this).data('copy')).then(function () {
+        bootbox.alert('Copied to clipboard!');
+      }, function () {
+        bootbox.alert('Failed to copy. Make sure you are using a modern browser. Please contact support if the issue continues.');
+      });
+    }
+    else {
+      bootbox.alert('Failed to copy. Copy to clipboard only works for HTTPS sites for security.');
+    }
+  });
+
 });

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -47,6 +47,12 @@
     .readonly-form-control {
         background: $tertiary-background;
     }
+    .button-container {
+        text-align: right;
+    }
+    .button-container .copy-to-clipboard {
+        margin: -.5em 0 .75em;
+    }
 }
 #closeNotebookAutocomplete {
     padding: 5px 10px;

--- a/app/views/modals/_notebook_metric_details.slim
+++ b/app/views/modals/_notebook_metric_details.slim
@@ -17,12 +17,17 @@ div.modal.fade id="metricsViews" aria-labelledby="notebookViewsHeader" aria-desc
               th # Views
               th Last View
             tbody
+              -emails = ""
               -@unique_viewers.sort_by {|_person,info| -info[:count]}.each do |person,info|
                 tr
                   td ==person.user_name
                   td ==person.org
                   td ==info[:count]
                   td data-sort="#{info[:last]}" ==render partial: "time_ago", locals: {time: info[:last]}
+                -emails = emails + person.email + ";"
+        -if emails != ""
+          div.button-container
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -49,12 +54,17 @@ div.modal.fade id="metricsRuns" aria-labelledby="notebookRunsHeader" aria-descri
               th # Runs
               th Last Run
             tbody
+              -emails = ""
               -@unique_runners.sort_by {|_person,info| -info[:count]}.each do |person,info|
                 tr
                   td ==person.user_name
                   td ==person.org
                   td ==info[:count]
                   td data-sort="#{info[:last]}" ==render partial: "time_ago", locals: {time: info[:last]}
+                -emails = emails + person.email + ";"
+        -if emails != ""
+          div.button-container
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -80,11 +90,16 @@ div.modal.fade id="metricsStars" aria-labelledby="notebookStarsHeader" aria-desc
               th Org
               th Star
             tbody
+              -emails = ""
               -@stars.each do |user|
                 tr
                   td ==user.user_name
                   td ==user.org
                   td 1
+                -emails = emails + user.email + ";"
+        -if emails != ""
+          div.button-container
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -111,6 +126,7 @@ div.modal.fade id="metricsEdits" aria-labelledby="notebookEditsHeader" aria-desc
               th Action
               th Time
             tbody
+              -emails = ""
               -@edit_history.each do |edit|
                 -revision = @revisions[edit.tracking]
                 tr
@@ -121,6 +137,10 @@ div.modal.fade id="metricsEdits" aria-labelledby="notebookEditsHeader" aria-desc
                   -else
                     td ==edit.action
                   td data-sort="#{edit.updated_at}" ==render partial: "time_ago", locals: {time: edit.updated_at}
+                -emails = emails + edit.user.email + ";"
+        -if emails != ""
+          div.button-container
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"

--- a/app/views/modals/_notebook_metric_details.slim
+++ b/app/views/modals/_notebook_metric_details.slim
@@ -17,17 +17,17 @@ div.modal.fade id="metricsViews" aria-labelledby="notebookViewsHeader" aria-desc
               th # Views
               th Last View
             tbody
-              -emails = ""
+              -usernames = ""
               -@unique_viewers.sort_by {|_person,info| -info[:count]}.each do |person,info|
                 tr
                   td ==person.user_name
                   td ==person.org
                   td ==info[:count]
                   td data-sort="#{info[:last]}" ==render partial: "time_ago", locals: {time: info[:last]}
-                -emails = emails + person.email + ";"
-        -if emails != ""
+                -usernames = usernames + person.user_name + ";"
+        -if usernames != ""
           div.button-container
-            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{usernames.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -54,17 +54,17 @@ div.modal.fade id="metricsRuns" aria-labelledby="notebookRunsHeader" aria-descri
               th # Runs
               th Last Run
             tbody
-              -emails = ""
+              -usernames = ""
               -@unique_runners.sort_by {|_person,info| -info[:count]}.each do |person,info|
                 tr
                   td ==person.user_name
                   td ==person.org
                   td ==info[:count]
                   td data-sort="#{info[:last]}" ==render partial: "time_ago", locals: {time: info[:last]}
-                -emails = emails + person.email + ";"
-        -if emails != ""
+                -usernames = usernames + person.user_name + ";"
+        -if usernames != ""
           div.button-container
-            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{usernames.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -90,16 +90,16 @@ div.modal.fade id="metricsStars" aria-labelledby="notebookStarsHeader" aria-desc
               th Org
               th Star
             tbody
-              -emails = ""
+              -usernames = ""
               -@stars.each do |user|
                 tr
                   td ==user.user_name
                   td ==user.org
                   td 1
-                -emails = emails + user.email + ";"
-        -if emails != ""
+                -usernames = usernames + user.user_name + ";"
+        -if usernames != ""
           div.button-container
-            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{usernames.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"
@@ -126,7 +126,7 @@ div.modal.fade id="metricsEdits" aria-labelledby="notebookEditsHeader" aria-desc
               th Action
               th Time
             tbody
-              -emails = ""
+              -usernames = ""
               -@edit_history.each do |edit|
                 -revision = @revisions[edit.tracking]
                 tr
@@ -137,10 +137,10 @@ div.modal.fade id="metricsEdits" aria-labelledby="notebookEditsHeader" aria-desc
                   -else
                     td ==edit.action
                   td data-sort="#{edit.updated_at}" ==render partial: "time_ago", locals: {time: edit.updated_at}
-                -emails = emails + edit.user.email + ";"
-        -if emails != ""
+                -usernames = usernames + edit.user.user_name + ";"
+        -if usernames != ""
           div.button-container
-            button.btn.btn-primary.copy-to-clipboard data-copy="#{emails.chop}" Copy Users to Clipboard
+            button.btn.btn-primary.copy-to-clipboard data-copy="#{usernames.chop}" Copy Users to Clipboard
         div.modal-footer
           div
             button.btn.btn-danger data-dismiss="modal"


### PR DESCRIPTION
Added buttons on bottom of metric modals to quick copy all of the user emails.

Closes #550. The only thing is this only works with HTTPS websites. The old method to do it for HTTP sites requires old browsers which we block. Maybe there is another way, but this seems to be the only way.