### PR TITLE
Ensure that HTML descriptions that are truncated for search results don't break the display

### DIFF
--- a/app/views/application/_table_nb_description.slim
+++ b/app/views/application/_table_nb_description.slim
@@ -2,10 +2,10 @@
   div.nb-description.comment.more
     span.sr-only Description of Notebook:
     p.minimize
-      ==nb.description.truncate(500,omission: "...")
+      ==strip_tags(nb.description.truncate(500,omission: "..."))
     a.view-full.tooltip-big title="#{simple_format(h(nb.description))}" tabindex="0" Read Full
 -else
   div.nb-description.comment.more
     span.sr-only Description of Notebook:
     p
-      ==nb.description.truncate(500,omission: "...")
+      ==nb.description


### PR DESCRIPTION
BUT, there will be more to follow on
Closes #650