### PR TITLE
Allow for creation of a description template

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -985,6 +985,15 @@ $(document).ready(function(){
           $('#stageUpload').modal('show');
           $('#uploadFileModal').modal("hide");
           $('#uploadFileSubmit').attr('disabled', false);
+          var descriptionTextarea = $('#stageDescription');
+          var checkModalRendered = setInterval(function() {
+            if (descriptionTextarea[0].scrollHeight > 1) {
+              document.addEventListener('keydown', autoSize);
+              let value = descriptionTextarea[0].scrollHeight + 2;
+              descriptionTextarea.css("height", value + "px");
+              clearInterval(checkModalRendered);
+            }
+          }, 100) // check every 100ms
         },
         error: function(response) {
           $(document).trigger("upload_error", response);

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -95,7 +95,8 @@
 .agree p {
     text-align: center;
 }
-textarea.form-control {
+textarea.form-control,
+textarea#descriptionField {
     min-height: 34px;
 }
 .modal-header .close {

--- a/app/views/modals/_upload.slim
+++ b/app/views/modals/_upload.slim
@@ -40,7 +40,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Title
-            input.form-control type="text" id="stageTitle" name="title" placeholder="Enter a title for your notebook" required=true
+            input.form-control type="text" id="stageTitle" name="title" autofocus=true placeholder="Enter a title for your notebook" required=true
           div.help-block.with-errors
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.form-group id="stageOverwrite" hidden="true"
@@ -53,7 +53,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Description
-            textarea.form-control id="stageDescription" name="description" placeholder="Enter a description of this notebook" required=true #{GalleryConfig.notebooks.description_template}
+            textarea.form-control.auto-expand id="stageDescription" name="description" placeholder="Enter a description of this notebook" required=true #{GalleryConfig.notebooks.description_template}
           div.help-block.with-errors
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.form-group

--- a/app/views/modals/_upload.slim
+++ b/app/views/modals/_upload.slim
@@ -53,7 +53,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
         div.form-group.has-feedback
           div.input-group
             span.input-group-addon.upload-addon Description
-            textarea.form-control id="stageDescription" name="description" placeholder="Enter a description of this notebook" required=true
+            textarea.form-control id="stageDescription" name="description" placeholder="Enter a description of this notebook" required=true #{GalleryConfig.notebooks.description_template}
           div.help-block.with-errors
           span.glyphicon.form-control-feedback aria-hidden="true"
         div.form-group

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -16,7 +16,7 @@ div.content-container
         div id="titleEdit" style="display:none;"
           form enctype="multipart/form-data" role="form" id="editTitleForm"
             div.input-group data-toggle="tooltip" title="Notebook Title"
-              textarea.form-control id="editTitle" type="text" name="title" ==@notebook.title
+              textarea.form-control id="editTitle" name="title" placeholder="Enter a title for your notebook" ==@notebook.title
             div.form-group.edit-buttons
               button.btn.btn-success id="titleEditSubmit" type="submit" style="float:left" Update
               a id="titleEditCancel"
@@ -231,7 +231,7 @@ div.content-container
           span.sr-only Edit description
     form id="descriptionEditForm" enctype="multipart/form-data" role="form" style="display: none"
       div.input-group data-toggle="tooltip" title="Edit description here"
-        textarea id="descriptionField" ==@notebook.description
+        textarea id="descriptionField" placeholder="Enter a description of this notebook" ==@notebook.description
       div.form-group.edit-buttons
         button.btn.btn-success id="descriptionEditSubmit" style="float:left" Update
         a id="descriptionEditCancel"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -152,6 +152,15 @@ video:
 # Notebook entries
 notebooks:
   learning:
+  description_template:
+
+# Multi-line description Example
+# description_template: |
+#   # Purpose
+#   # Requirements
+#     * Data Files
+#     * Remote Systems
+#     * Custom Packages
 
 # Registration settings
 registration:


### PR DESCRIPTION
Closes #531

@manfromjupyter I think we should increase the default size of the description input (height) or have it auto scale, because the second you shove a description template in there it is just lost in the noise with the scroll bar but the box doesn't enlarge itself.  Can you take a look into that.