### PR TITLE
Ensures that as long as a tag exists, the user will remain subscribed…

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -2,7 +2,19 @@
 class Tag < ApplicationRecord
   belongs_to :user
   belongs_to :notebook
-  has_many :subscriptions, as: :sub, dependent: :destroy
+  has_many :subscriptions, as: :sub
+  before_destroy  { |tag|
+    subscriptions = Subscription.where(sub_type: "tag").where(sub_id: tag.id)
+    tag = Tag.where(tag: tag.tag).where("id != ?",tag.id).first
+    if(tag)
+      subscriptions.each do |subscription|
+        subscription.sub_id = tag.id
+        subscription.save!
+      end
+    else
+      subscriptions.destroy_all
+    end
+  }
 
   validates :tag, format: { with: /\A[a-z0-9-]+\z/, message: 'Tags can only use lowercase, digits and hyphens' }
   validates :tag, :notebook, presence: true


### PR DESCRIPTION
… to it

Moves the subscription from the deleted instance of a tag to another Closes #353 
If all instances of a tag are deleted, the subscription goes away, but this is an acceptable trade-off to the alternatives

#360 should actually still be handled better, but this is a stop-gap