### PR TITLE
Fixed borders of revisions when on and off of deprecated notebook pages

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -298,7 +298,7 @@ body.page-admin header {
     position: relative;
     text-decoration: none !important;
     text-transform: lowercase;
-    top: 2.5px;
+    top: 2px;
     .logo-nb {
         background: $secondary-color;
         border-radius: .6em;
@@ -3094,7 +3094,7 @@ span.revision-version {
     top: -.1em;
 }
 .banner {
-    margin-top: -1em;
+    margin-top: -1.05em;
     padding: .5em;
     p {
         display: inline-block;
@@ -3130,15 +3130,18 @@ span.revision-version {
 .revision-banner {
     background: $green-banner-background-color;
     border-bottom: 1px solid #bad2b7;
-    margin-top: -1em;
+    border-top: 1px solid #bad2b7;
+    margin-top: -1.05em;
     #oldNotebookRevision & {
         background: $blue-banner-background-color;
         border-bottom: 1px solid #c0e2f5;
+        border-top: 1px solid #c0e2f5;
     }
     a {
         color: #2d70aa;
     }
     body.notebook-deprecated & {
+        border-top: 0;
         margin-top: 0;
     }
 }


### PR DESCRIPTION
Closes #738 

![just revision banner](https://user-images.githubusercontent.com/51969207/212128186-a5134d9b-95db-486f-bfc5-a7cc85eaf79e.PNG)
![both banners](https://user-images.githubusercontent.com/51969207/212128187-5265e0f3-005b-4e5c-aee7-da31bbff9bc8.PNG)
![just deprecation banner](https://user-images.githubusercontent.com/51969207/212128189-169b4622-78ac-471b-a4e3-2333a1636d07.PNG)

+ Confirmed looks good on all themes.