### PR TITLE
Fixed wrapping issues in admin and user detail's tables

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -1231,10 +1231,10 @@ $(document).ready(function(){
     'searching': false,
     'info': false,
     'columnDefs': [
-      { 'responsivePriority': 1000, 'targets':[4,5] },
+      { 'responsivePriority': 1000, 'targets':[4] },
       { 'responsivePriority': 100, 'targets':[3] },
       { 'responsivePriority': 10, 'targets':[1,2] },
-      { 'responsivePriority': 1, 'targets':[0,6] },
+      { 'responsivePriority': 1, 'targets':[0,-1] },
     ],
   });
 

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2755,10 +2755,16 @@ body.page-summary .form-group {
 }
 
 /* ===== Users Page (/users) ===== */
-body.page-users table th .form-control {
-    display: block;
-    max-width: 100%;
-    padding-right: 0 !important;
+body.page-users #userTable {
+    th .form-control {
+        display: block;
+        max-width: 100%;
+        padding-right: 0 !important;
+    }
+    td:first-child {
+        max-width: 250px;
+        word-wrap: break-word;
+    }
 }
 .checkbox-container {
     float: right;
@@ -3529,6 +3535,10 @@ body.page-admin-import {
     .col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
         padding: 0;
     }
+}
+table.tabular td {
+    max-width: 150px;
+    word-wrap: break-word;
 }
 
 /* ===== UNSUPPORTED BROWSERS ===== */

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2764,6 +2764,9 @@ body.page-users #userTable {
     td:first-child {
         max-width: 250px;
         word-wrap: break-word;
+        @media all and (max-width: 800px) {
+            max-width: 150px;
+        }
     }
 }
 .checkbox-container {

--- a/app/views/users/detail.slim
+++ b/app/views/users/detail.slim
@@ -42,7 +42,7 @@ div.content-container
       div.panel.panel-primary
         div.panel.panel-heading
           h2.panel-title Similar users
-        table.table.tabular.centered-table id="similarUserTable"
+        table.table.tabular.centered-table
           caption.sr-only Similar Users
           thead
             tr

--- a/app/views/users/detail.slim
+++ b/app/views/users/detail.slim
@@ -42,7 +42,7 @@ div.content-container
       div.panel.panel-primary
         div.panel.panel-heading
           h2.panel-title Similar users
-        table.table.tabular.centered-table
+        table.table.tabular.centered-table id="similarUserTable"
           caption.sr-only Similar Users
           thead
             tr


### PR DESCRIPTION
- Fixed wrapping issue with users, groups, tags, and notebooks on all of the admin pages with graphs and the user details page.
- Fixed table-compression issue of users with too long of an email or username on the /users page.

Closes #793 