### PR TITLE
Fixed outline of metric and lock icons

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1385,7 +1385,6 @@ span.deprecated-tag {
 .action-icon {
     color: $darker-icon-color;
     margin: 0 .4em;
-
 }
 .nb-stats .action-icon {
     margin: 0;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -51,7 +51,8 @@ strong, b {
     font-weight: $bold-weight;
 }
 a:focus,
-.btn:focus {
+.btn:focus,
+.tagLogoLock:focus {
     outline: 1px dotted $primary-link-color;
 }
 time:focus {
@@ -1577,6 +1578,11 @@ table .glyphicon-alert {
     height: 20px;
     & > a {
         color: inherit;
+        padding: .75em 0 0 .3em;
+        margin-right: -.3em;
+    }
+    & > a.health-metric {
+        padding-right: .3em;
     }
     img {
         margin-right: 6px;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1233,7 +1233,7 @@ span.deprecated-tag {
 .nb-stats {
     .badge-notify {
         left: 0;
-        top: 1px;
+        top: -10px;
     }
     .badge {
         background-color: inherit;
@@ -1385,6 +1385,10 @@ span.deprecated-tag {
 .action-icon {
     color: $darker-icon-color;
     margin: 0 .4em;
+
+}
+.nb-stats .action-icon {
+    margin: 0;
 }
 #notebookJumbo .notebook-actions {
     display: block;
@@ -1576,14 +1580,6 @@ table .glyphicon-alert {
     clear: both;
     display: block;
     height: 20px;
-    & > a {
-        color: inherit;
-        padding: .75em 0 0 .3em;
-        margin-right: -.3em;
-    }
-    & > a.health-metric {
-        padding-right: .3em;
-    }
     img {
         margin-right: 6px;
         max-height: 24px;
@@ -1612,6 +1608,21 @@ table .glyphicon-alert {
     .comments-metric {
         display: none;
     }
+}
+.nb-stats a {
+    margin-left: .4em;
+}
+#tagsDisplay,
+.tag-edit-mode,
+.nb-stats {
+   & > a {
+       color: inherit;
+       padding: .75em 0 0 .3em;
+       margin-right: -.3em;
+   }
+   & > a.health-metric {
+       padding-right: .3em;
+   }
 }
 #tagsEditForm {
     div.input-group {

--- a/app/views/application/_notebook_metadata_metrics.slim
+++ b/app/views/application/_notebook_metadata_metrics.slim
@@ -58,7 +58,7 @@
     span.badge.badge-notify =notebook.shares.size
     span.hidden aria-hidden="true" #{")"}
   span.hidden aria-hidden="true" #{" | "}
-a.tooltips href="#{metrics_notebook_path(notebook)}#metricsHealth" title=(notebook.notebook_summary.health_description == nil ? "Undetermined Health: Notebook has not been executed yet" : "#{notebook.notebook_summary.health_description}") rel="nofollow"
+a.health-metric.tooltips href="#{metrics_notebook_path(notebook)}#metricsHealth" title=(notebook.notebook_summary.health_description == nil ? "Undetermined Health: Notebook has not been executed yet" : "#{notebook.notebook_summary.health_description}") rel="nofollow"
   -if notebook.unhealthy?
     span.fa.fa-medkit.action-icon.view-summary.health.unhealthy
     span.sr-only ==notebook.notebook_summary.health_description


### PR DESCRIPTION
Closes #542 

Ideally need to refactor our stats sections to all be styled the same way with the same container but didn't want to make this PR too big.