### PR TITLE
Display group description on Notebook listing

### DIFF
--- a/app/assets/javascripts/groups.js
+++ b/app/assets/javascripts/groups.js
@@ -35,6 +35,7 @@ $(document).ready(function() {
       };
       $('#groupNotebooks').toggle();
       $('#groupLanding').toggle();
+      $('#groupDescription').toggle();
     return false;
   });
 

--- a/app/views/groups/show.slim
+++ b/app/views/groups/show.slim
@@ -50,6 +50,9 @@ div.content-container.mobile-expanding
               span.sr-only
                 |  landing page icon
               |  to make that notebook the landing page.
+-if !@group.description.blank?
+  div.content-container id='groupDescription' style=(@landing.nil? ? "display: block;" : "display: none;")
+    ==render_description(@group.description)
 
 -if @notebooks.empty?
   div.content-container


### PR DESCRIPTION
Closes #301 
@manfromjupyter You are the UI man, but here is what I am thinking.  It only shows up on the listing, not with the landing page as a landing page should be self-descriptive.