### PR TITLE
Code cell(s) smushed on some notebooks

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2807,6 +2807,7 @@ body.page-users #userTable {
 
 /* ===== Code Cell Pages notebooks/{ID}/code_cells/{ID} ===== */
 .cell-health-container {
+    clear: both;
     height: 0;
 }
 #notebookDisplay,


### PR DESCRIPTION
Fixes issue where a CSS floated objected on a notebook before a code cell was causing code cell on NBGallery to get all smushed.

Confirmed notebook page and code cell pages work without problems with this change.