### PR TITLE
Track parent_uuid

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -977,6 +977,7 @@ class NotebooksController < ApplicationController
       @notebook.public = !params[:private].to_bool
       @notebook.creator = @user
       @notebook.owner = @owner
+      @notebook.parent_uuid = params[:parent_uuid] if params[:parent_uuid].present?
     end
 
     # Fields defined by extensions

--- a/app/views/modals/_upload.slim
+++ b/app/views/modals/_upload.slim
@@ -69,6 +69,7 @@ div.modal.fade.notebookModalsSmall id="stageUpload" aria-labelledby="stageUpload
               input type="checkbox" id="stagePrivate" name="private" value="true"
               span id="stagePrivate" This notebook is private (optional)
         input type="hidden" name="staging_id" id="stagingId" value="#{params[:staged] ? params[:staged] : ''}"
+        input type="hidden" name="parent_uuid" id="parentUUID" value="#{params[:parent_uuid] ? params[:parent_uuid] : ''}"
         ==render partial: "tos"
         div.modal-footer
           div class="form-group"

--- a/db/migrate/20230407125703_add_parent_uuid_to_notebooks.rb
+++ b/db/migrate/20230407125703_add_parent_uuid_to_notebooks.rb
@@ -1,0 +1,9 @@
+class AddParentUuidToNotebooks < ActiveRecord::Migration[6.1]
+  def up
+    add_column :notebooks, :parent_uuid, :string, null: true
+    add_index :notebooks, :parent_uuid
+  end
+  def down
+    remove_column :notebooks, :parent_uuid
+  end
+end


### PR DESCRIPTION
Track the parent_uuid of a notebook when the notebook is uploaded using "fork notebook" from Jupyterlab extensions
Closes #711 