### PR TITLE
Group Search Result Fixes

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2376,6 +2376,7 @@ p.no-group-members {
     & .groupSearchResults {
         font-size: 110%;
         text-align: left;
+        word-break: break-word;
     }
 }
 #searchTable td {

--- a/app/views/application/_group_listing.slim
+++ b/app/views/application/_group_listing.slim
@@ -1,18 +1,5 @@
 -group_array.each do |group, count|
   li.list-group-item.groupSearchResults
-    a.tooltips href="#{url_for(group)}" title="#{group.description.nil? || group.description == '' ? '(no description)' : group.description}"
+    a.tooltips href="#{url_for(group)}" title="#{group.description.nil? || group.description == '' ? '(no description)' : group.description}" aria-label='Group "#{group.name}" with description "#{group.description}" contains #{group.notebooks.count} notebooks'
       | #{group.name}
-      span.sr-only #{" "}
-      span.hidden aria-hidden="true" #{"("}
-      -if group.description.nil? || group.description == ''
-        span.sr-only with no description
-      -else
-        span.sr-only #{'with description "' + group.description + '"'}
-      span.hidden aria-hidden="true" #{") ("}
-      span.sr-only #{"contains "}
       span.badge.searchResultGroup.tooltip-right tabindex="0" title="#{group.notebooks.count} Notebooks" ==group.notebooks.count
-      -if group.notebooks.count == 1
-        span.sr-only #{" notebook"}
-      -else
-        span.sr-only #{" notebooks"}
-      span.hidden aria-hidden="true" #{")"}

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -35,7 +35,7 @@ div.content-container
                 ul.groupSearches
                   -@groups.first(3).each do |group, count|
                     li.groupSearchResults
-                      a.searchResultsGroup.tooltips href="#{url_for(group)}" title="#{count} notebooks = #{group.description}"
+                      a.searchResultsGroup.tooltips href="#{url_for(group)}" title="#{count} notebooks = #{group.description}" aria-label='Group "#{group.name}" with description "#{group.description}" contains #{count} notebooks'
                         span.join #{group.name}
           td
             -unless defined? suggested_view

--- a/app/views/notebooks/recommended.slim
+++ b/app/views/notebooks/recommended.slim
@@ -14,9 +14,9 @@ div.content-container id="recommendationsContainer"
         ul
           -@groups.each do |group, count|
             li.groupSearchResults
-              a.tooltips href="#{url_for(group)}" title="#{group.description}"
+              a.tooltips href="#{url_for(group)}" title="#{group.description}" aria-label='Group "#{group.name}" with description "#{group.description}" contains #{count} notebooks'
                 span #{group.name}
-                span.badge.searchResultGroup =count
+                span.badge.searchResultGroup ==count
     br
   -unless @tag_text_with_counts.empty?
     h2 Tags Recommended for Me
@@ -26,9 +26,9 @@ div.content-container id="recommendationsContainer"
         ul
           -@tag_text_with_counts.each do |tag_text, count|
             li
-              a.recommended-tag href="#{tag_path(tag_text)}"
+              a.recommended-tag href="#{tag_path(tag_text)}" aria-label='Tag "#{tag_text }" contains #{count} notebooks'
                 span.label.tag style="background-color: #{color_for(tag_text)}" ==tag_text
-                span.badge.searchResultTag =count
+                span.badge.searchResultTag ==count
     br
   -if @notebooks.empty?
     div.content-container.center


### PR DESCRIPTION
Closes #530, #854

1. Fixed cosmetic issue of group results running off side of page if a group is found in a search and the group name is exceptional. Didn't apply to tags because tags have to be exact and it seems impossible someone would do a search for say a 40 character string with no spaces and it perfectly matched a tag someone added.
2. For group pages, recommended page for groups, and search results including groups made them fully accessible to blind and low vision people using screen readers.

Eventually we should update our version of tooltipster. This version despite claiming to work with HTML within tooltips, it's not working. Think it's our version of Rails. I confirmed the JS is perfect. But anyway this would allow us to clean up those group descriptions by saying "Group Description" in bold then the large array of randomly formatted descriptions