### PR TITLE
Only attempt to send the email if the previous owner is not nil

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -499,7 +499,7 @@ class NotebooksController < ApplicationController
       end
 
     # Email previous owner if ownership was changed by an admin (not them)
-    if @notebook.owner_type == "User" && @owner.id != @user.id
+    if @owner && @owner.id != @user.id
       NotebookMailer.notify_owner_of_change(
         @notebook,
         @owner,


### PR DESCRIPTION
Used to check AFTER changing the ownership which changed owner_type Threw an error when transferring from Group->User since @owner was nil
Closes #858 