### PR TITLE
Changing search to filter results in datatables

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -1210,6 +1210,7 @@ $(document).ready(function(){
   $('.review-table:not(#allReviewsTable)').DataTable({
     'responsive': true,
     'paging': false,
+    'language': { 'search': 'Filter results:' },
     drawCallback: function(settings){
       reapplyTooltips($('#reviewsForNotebooksTable'))
     },
@@ -1232,6 +1233,7 @@ $(document).ready(function(){
   $('#allReviewsTable').DataTable({
     'responsive': true,
     'paging': false,
+    'language': { 'search': 'Filter results:' },
     'columnDefs': columnDefs,
     drawCallback: function(settings){
       reapplyTooltips($('#allReviewsTable'))
@@ -1243,6 +1245,7 @@ $(document).ready(function(){
     'responsive': true,
     'paging': false,
     'ordering': false,
+    'language': { 'search': 'Filter results:' },
     'columnDefs': [
       { 'responsivePriority': 100, 'targets':[1] },
       { 'responsivePriority': 1, 'targets':[0,2,3,4] },
@@ -1255,6 +1258,7 @@ $(document).ready(function(){
     'responsive': true,
     'paging': false,
     'ordering': false,
+    'language': { 'search': 'Filter results:' },
     'columnDefs': [
       { 'responsivePriority': 100, 'targets':[1] },
       { 'responsivePriority': 10, 'targets':[5] },

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -123,7 +123,7 @@ textarea#descriptionField {
 
 /* ===== Inline Forms ===== */
 // Override bootstrap styling
-label {
+form label {
     font-weight: 400;
     margin-bottom: 0;
 }


### PR DESCRIPTION
Closes #870 

The `label` change to `form label` was to fix an issue with our datatables where the Filter Results section was now sinking down into the table.