### PR TITLE
Resolves _ problem with search results

### DIFF
--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -6,12 +6,12 @@
   -if char == "#{"\""}" && !inQuote
     -inQuote = true
   -elsif char == " " && inQuote
-    -raw_query[index] = "_"
+    -raw_query[index] = "_-_"
   -elsif char == "#{"\""}" && inQuote
     -inQuote = false
 -query = raw_query.join.split(" ")
 -query.each do |term|
-  -term = term.gsub("_"," ")
+  -term = term.gsub("_-_"," ")
   -if !term.include? ":"
     -search = search + " " + term
   -else


### PR DESCRIPTION
Related to #877

We were using _ as a temporary tokenizer in quoted strings, switched to something unique enough that won't be used for that tokenization.  '_-_'