### PR TITLE
Fixed 2 dark theme issues

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -3612,7 +3612,6 @@ body.dark-theme {
         color: $dark-theme-background-color;
     }
     #topNavbar .logo-link .logo-gallery,
-    .edit_user label,
     .edit_user i,
     .edit_user em,
     &.page-users-edit #main p,
@@ -3703,11 +3702,11 @@ body.dark-theme {
     .sparkline,
     #viewAsFullPage,
     #notebookCellPagination li.active span,
-    .dataTables_filter,
-    .dataTables_filter input[type="search"],
-    .dataTables_length,
-    .dataTables_info,
-    .dataTables_paginate,
+    #main .dataTables_filter,
+    #main .dataTables_filter input[type="search"],
+    #main .dataTables_length,
+    #main .dataTables_info,
+    #main .dataTables_paginate,
     a.paginate_button.current {
         filter: invert(100%);
     }


### PR DESCRIPTION
Closes #886 

Fixes 2 dark theme issues
1. Modals of tables ,example metrics tables had several components around the table invisible (white on white)
2. Edit user page had white labels on light gray backgrounds.