### PR TITLE
Address long filenames causing an error in Jupyter

### DIFF
--- a/app/assets/javascripts/run_in_jupyter.js.erb
+++ b/app/assets/javascripts/run_in_jupyter.js.erb
@@ -96,7 +96,8 @@ $(document).ready(function() {
       $.get('/notebooks/' + id + '/metadata', function(metadata) {
         if(type == 'notebook'){
           $.get('/notebooks/' + id + '/download?run=true' + ref, function(notebook) {
-            var name = (metadata['title'] + '.ipynb').replace(/\//g,'∕');
+            // Truncate extra long names because they will cause a file name too long error when creating -checkpoint files
+            var name = (metadata['title'].slice(0,220) + '.ipynb').replace(/\//g,'∕');
             check_for_existence(name,url,notebook,user_interface);
           });
         }


### PR DESCRIPTION
Closes #885
Limits base filenames (minus extension) to 220 characters so filename + "-checkpoint" + extension stays below 255 character limit