### PR TITLE
make My Groups visible even if user has no groups

### DIFF
--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -225,16 +225,15 @@ html lang="en"
                             li
                               a href="#{subscriptions_path}"
                                 span.tab My Subscriptions
-                            -unless @user.groups.count.zero?
-                              li
-                                a href="#{groups_user_path(@user)}"
-                                  span.tab My Groups
-                                  span.sr-only #{" "}
-                                  span.hidden aria-hidden="true" #{"("}
-                                  span.badge.pull-right ==@user.groups.count
-                                  span.sr-only #{" total"}
-                                  span.hidden aria-hidden="true" #{")"}
-                                  li.divider role="separator"
+                            li
+                              a href="#{groups_user_path(@user)}"
+                                span.tab My Groups
+                                span.sr-only #{" "}
+                                span.hidden aria-hidden="true" #{"("}
+                                span.badge.pull-right ==@user.groups.count
+                                span.sr-only #{" total"}
+                                span.hidden aria-hidden="true" #{")"}
+                                li.divider role="separator"
                             -if GalleryConfig.reviews_enabled
                               li.dropdown-header.filter-item All Resources
                               li


### PR DESCRIPTION
While looking the Groups bug, it occurred to me that there isn't really any way for users to create groups if they aren't already in one. This is a simple change that makes the groups functionality a bit more discoverable.

![image](https://github.com/nbgallery/nbgallery/assets/7386900/f21027db-19f8-45af-b3b8-8b13c3fc1e29)
