### PR TITLE
Removed Jupyter Classic as an interface option

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -146,9 +146,6 @@ run_in_jupyter:
     - name: "Jupyter Notebook"
       key: "notebook"
       url: "notebooks/"
-    - name: "Jupyter Classic"
-      key: "classic"
-      url: "nbclassic/notebooks/"
 
 # Terms of Service Agreement
 tos:


### PR DESCRIPTION
Closes #906 

Removes the option of "Jupyter Classic" people may set for their environment and removes existing ones that have been set.