### PR TITLE
Fix a trusted tag edge case

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -601,7 +601,7 @@ class NotebooksController < ApplicationController
   def tags=
     tags = Tag.from_csv(params[:tags], user: @user, notebook: @notebook)
     tags.each do |tag|
-      raise Notebook::BadUpload.new('bad tag', tag.errors) if tag.invalid?
+      raise Notebook::BadUpload.new('bad tag', tag.errors) if tag.new_record? && tag.invalid?
     end
 
     @notebook.tags = tags
@@ -960,7 +960,7 @@ class NotebooksController < ApplicationController
   def parse_tags
     tags = Tag.from_csv(params[:tags], user: @user, notebook: @notebook)
     tags.each do |tag|
-      raise Notebook::BadUpload.new('bad tag', tag.errors) if tag.invalid?
+      raise Notebook::BadUpload.new('bad tag', tag.errors) if tag.new_record? && tag.invalid?
     end
     tags
   end


### PR DESCRIPTION
Use Case:
- User A is an admin
- User A adds Trusted to a notebook
- User A stops being an admin
- User B (admin or not) tries to add tag "foo" to a notebook
- User B would be blocked because the trusted tag is no longer valid

How it's fixed
- tag.invalid is only checked for NEW tag records added to the notebook

Closes #925