### PR TITLE
Enable changelog option in admin bulk import and fix typos

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -310,7 +310,7 @@ class AdminController < ApplicationController
           stage.destroy
           next
         elsif @metadata[key][:updated].to_datetime == notebook.updated_at.to_datetime
-          import_warning(file.full_name, @metadata[key],"The <a href='#{notebook_path(notebook)}'>notebook</a> in the gallery appears to have already been udpated to this version and will note be updated.")
+          import_warning(file.full_name, @metadata[key],"The <a href='#{notebook_path(notebook)}'>notebook</a> in the gallery appears to have already been updated to this version and will not be updated.")
           stage.destroy
           next
         end
@@ -347,7 +347,11 @@ class AdminController < ApplicationController
       if (new_record || (stage.content != old_content))
         notebook.content = stage.content # saves to cache
         notebook.commit_id = stage.uuid
-        commit_message = "Notebook Imported by Admininistrator"
+        if !@metadata[key][:changelog].nil?
+          commit_message = @metadata[key][:changelog]
+        else
+          commit_message = "Notebook Imported by Administrator"
+        end
         if !@metadata[key][:updated].nil?
           notebook.content_updated_at = @metadata[key][:updated].to_datetime
         end
@@ -563,7 +567,7 @@ class AdminController < ApplicationController
   def validate_import_metadata(metadata,file_name)
     valid = true
     if metadata.nil?
-      import_error(file_name, metadata,"No metaddata specified for the file.")
+      import_error(file_name, metadata,"No metadata specified for the file.")
       valid = false
     else
       if metadata[:title].blank?

--- a/app/views/admin/import.slim
+++ b/app/views/admin/import.slim
@@ -51,6 +51,7 @@ div.content-container
            "title":"Example Notebook",
            "description":"This is an example notebook to show how the exported notebooks look",
            "uuid":"5bc058c7-f651-4e39-a94c-cd5676fc676c", // Optional - Only required if the import needs to overwrite existing notebooks
+           "changelog":"This is a description of what was changed", // Optional - Summary of what was changed if overwriting an existing notebook
            "public":true, // Optional - Defaults to setting above if not specified
            "updater":"sample_user5", // Optional But will appear as "Unknown" in the UI if not specified
            "creator":"sample_user1", // Optional But will appear as "Unknown" in the UI if not specified

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,7 @@ The metadata.json should be an object with keys for each file (absent the .ipynb
          "title":"Example Notebook",
          "description":"This is an example notebook to show how the exported notebooks look",
          "uuid":"5bc058c7-f651-4e39-a94c-cd5676fc676c", // Optional - Only required if the import needs to overwrite existing notebooks
+         "changelog":"This is a description of what was changed", // Optional - Summary of what was changed if overwriting an existing notebook
          "public":true, // Optional - Defaults to setting above if not specified
          "updater":"sample_user5", // Optional But will appear as "Unknown" in the UI if not specified
          "creator":"sample_user1", // Optional But will appear as "Unknown" in the UI if not specified


### PR DESCRIPTION
Hello! So I've been playing around with the admin bulk notebooks importer, and I noticed that when I use it to update existing notebooks by providing a UUID, the revision history is always `Notebook Imported by Admininistrator`.

This PR fixes this typo and other typos in the same file, as well as giving you the option to provide a custom changelog summary using the new option `changelog` in your `metadata.json` file. Thanks!