### PR TITLE
Feedback and comments combination

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -473,7 +473,7 @@ $(document).ready(function(){
   });
 
   /* ===================================== */
-  /* ====== Recommendation Toggling ====== */
+  /* ====== Recommendation/Comments Toggling ====== */
   /* ===================================== */
   // Notebook "recommendations" similar notebooks and user also viewed stuff
   var prepareShelf = function(selector){
@@ -492,10 +492,12 @@ $(document).ready(function(){
     $('#notebookAddInfo').toggleClass('is-active');
     toggleAriaExpanded(this);
     if ($('#recommendationToggle').hasClass('is-active')) {
+      $('#commentsToggle').addClass('while-recommendations-open');
       $('#notebookAddInfo .shelf').css("display", "block");
       $('#dropdownRecommendationsAriaLabel').text('Collapse Recommendations Dropdown');
     }
     else {
+      $('#commentsToggle').removeClass('while-recommendations-open');
       $('#dropdownRecommendationsAriaLabel').text('Expand Recommendations Dropdown');
       $('#notebookAddInfo .shelf').delay(1000).queue(function(){
         $(this).css("display", "none")
@@ -503,6 +505,35 @@ $(document).ready(function(){
     }
     $(this).children('i').toggleClass('spin');
   });
+
+  $('#commentsToggle').on('click', function(e){
+    e.preventDefault();
+    $(this).toggleClass('is-active');
+    $('#commentsDisplay').toggleClass('panel-displayed');
+    $('#notebookDisplay').toggleClass('panel-displayed');
+    toggleAriaExpanded(this);
+    if ($('#commentsToggle').hasClass('is-active')) {
+      setTimeout(function() {
+        $('#commentsDisplay').css("display", "inline-block")
+      }, 250);
+    }
+    else {
+      setTimeout(function() {
+        $('#commentsDisplay').css("display", "none")
+      }, 250);
+    }
+    $(this).children('i').toggleClass('spin');
+  });
+
+  $('#newCommentContainer #notebookRun input').on('click', function(e){
+    if ($(this).prop('checked')) {
+      $('#notebookWorked').css("display", "block");
+    }
+    else {
+      $('#notebookWorked input').prop('checked', false);
+      $('#notebookWorked').css("display", "none");
+    }
+   });
 
   /* ===================================== */
   /* ===== Revisions - Edits ====== */
@@ -631,6 +662,11 @@ $(document).ready(function(){
     var length = this.value.length;
     var characterCountElement = $('#stageCommitMessage .remaining-characters-warning');
     remainingCharacterWarning(length, characterCountElement, 250);
+  })
+    $('#newCommentContainer Textarea').keyup(function(){
+    var length = this.value.length;
+    var characterCountElement = $('#newCommentContainer .remaining-characters-warning');
+    remainingCharacterWarning(length, characterCountElement, 1000);
   })
 
   /* ===================================== */

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1804,30 +1804,55 @@ p.description {
         background: #fff;
         color: $primary-link-color;
     }
+    &.while-recommendations-open {
+        border-bottom: 2px solid #000;
+        margin-top: -1px;
+        @media all and (max-width: 599px) {
+            border-radius: .5em .5em 0 0;
+            padding-bottom: .45em;
+        }
+    }
 }
 #notebookDisplay,
 #commentsDisplay {
     display: inline-block;
+    transition: .25s all;
     vertical-align: top;
 }
+
 #notebookDisplay {
-    width: 70%; // TEMPORARY!!!
+    width: 100%;
+    &.panel-displayed {
+        width: 70%;
+        @media all and (max-width: 599px) {
+            width: 60%;
+        }
+    }
 }
 #commentsDisplay {
     background-color: $secondary-background;
     margin-left: 1em;
     margin-top: -2.1em;
-    max-width: calc(30% - 1em);
     padding: 1em;
+    float: right;
     transition: .5s all;
+    width: 0%;
+    @media all and (max-width: 599px) {
+        background: 0;
+        border-left: 1px solid $primary-border-color;
+        padding: 0;
+    }
     .comment-block {
         background: #fff;
-        border-bottom: 1px solid #ccc;
+        border-bottom: 1px solid $primary-border-color;
         padding: .75em;
     }
     .comment-block-user {
         font-size: 14px;
         font-weight: bold;
+    }
+    .comment-block-user a {
+        word-break: break-word;
     }
     .comment-block time {
         font-family: monospace;
@@ -1865,9 +1890,38 @@ p.description {
             margin-left: .5em;
         }
     }
+}
+#newCommentContainer {
     textarea {
-        padding: 1em;
-        width: 100%;
+        padding: .5em;
+        margin-bottom: 0.25em;
+        max-width: 100%;
+        min-height: 4em;
+        min-width: 100%;
+    } 
+    & > div {
+        margin-bottom: 0;
+    }
+    input[type="checkbox"] {
+        margin: 0;
+        position: relative;
+        top: 1px;
+    }
+    .checkbox {
+        margin: 0;
+    }
+    label span {
+        margin-left: 0.25em;
+        font-weight: normal;
+    }
+    .button-container {
+        text-align: right;
+    }
+}
+#commentsDisplay.panel-displayed {
+    width: calc(30% - 1em);
+    @media all and (max-width: 599px) {
+        width: calc(40% - 1em);
     }
 }
 #notebookAddInfo {
@@ -1885,6 +1939,10 @@ p.description {
         height: unset;
         max-height: 350px;
         padding: 1em 0;
+    }
+    @media all and (max-width: 599px) {
+        border-top-right-radius: 0;
+        margin-top: -1.2em;
     }
 }
 .shelf-title {

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -505,7 +505,7 @@ table#searchTable {
     }
 }
 span.open-reviews,
-span.review-alert {
+span.notice-amount {
     background-color: $error-text-color;
     border-radius: .7em;
     color: #fff;
@@ -517,7 +517,7 @@ span.review-alert {
 }
 #headerIcons {
     transition: .25s all;
-    span.review-alert {
+    span.notice-amount {
       font-size: 81%;
       left: 4.5em;
       position: absolute;
@@ -529,8 +529,8 @@ span.review-alert {
           left: 8.9em;
       }
     }
-    body.page-home & span.review-alert,
-    body.page-notebook-search & span.review-alert {
+    body.page-home & span.notice-amount,
+    body.page-notebook-search & span.notice-amount {
         @media all and (max-width: 799px) {
             left: 7em;
         }
@@ -1756,6 +1756,7 @@ p.description {
 }
 
 /* ===== Recommended Shelf ===== */
+#commentsToggle,
 #recommendationToggle {
     background-color: #265a88;
     border-radius: .5em .5em 0 0;
@@ -1786,6 +1787,7 @@ p.description {
         border-radius: .5em;
     }
 }
+#commentsToggle,
 #recommendationToggle,
 #filterToggle {
     i {
@@ -1794,6 +1796,78 @@ p.description {
     }
     i.spin {
         transform: scaleY(-1);
+    }
+}
+#commentsToggle {
+    float: right;
+    span.notice-amount {
+        background: #fff;
+        color: $primary-link-color;
+    }
+}
+#notebookDisplay,
+#commentsDisplay {
+    display: inline-block;
+    vertical-align: top;
+}
+#notebookDisplay {
+    width: 70%; // TEMPORARY!!!
+}
+#commentsDisplay {
+    background-color: $secondary-background;
+    margin-left: 1em;
+    margin-top: -2.1em;
+    max-width: calc(30% - 1em);
+    padding: 1em;
+    transition: .5s all;
+    .comment-block {
+        background: #fff;
+        border-bottom: 1px solid #ccc;
+        padding: .75em;
+    }
+    .comment-block-user {
+        font-size: 14px;
+        font-weight: bold;
+    }
+    .comment-block time {
+        font-family: monospace;
+        font-size: 10pt;
+        margin-left: .5em;
+        opacity: .6;
+    }
+    .comment-body {
+        padding: .3em 0;
+        word-wrap: break-word;
+    }
+    .comment-metadata-secondary {
+        span.notebook-comment-metadata {
+            border-radius: 4px;
+            border: 1px solid #ccc;
+            color: #666;
+            display: inline-block;
+            padding: .2em;
+            margin-bottom: .2em;
+            margin-right: .25em;
+            i {
+                margin-right: .25em;
+            }
+            i.fa-times {
+                color: red;
+            }
+            i.fa-check {
+                color: green;
+            }
+        }
+    }
+    .comment-actions {
+        text-align: right;
+        a {
+            margin-left: .5em;
+        }
+    }
+    textarea {
+        padding: 1em;
+        width: 100%;
     }
 }
 #notebookAddInfo {
@@ -4067,7 +4141,7 @@ body.ultra-dark-theme {
     .view-summary.fa-star,
     .tag,
     .carousel-inner,
-    .review-alert,
+    .notice-amount,
     .open-reviews,
     .author-rep,
     div.stderr,
@@ -4250,7 +4324,7 @@ body.larger-text-mode {
     #expandableSearch {
         font-size: 22px;
     }
-    #headerIcons span.review-alert {
+    #headerIcons span.notice-amount {
         font-size: 88%;
     }
     #navbarSearchBar .searchFieldBox {

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -91,6 +91,7 @@ class NotebooksController < ApplicationController
   # GET /notebooks/:uuid
   def show
     if request.format.html?
+      @comments = Comment.where(notebook_id: @notebook.id)
       @more_like_this = @notebook.more_like_this(@user, count: 10).includes(:updater)
       @also_viewed = @notebook.users_also_viewed(@user).limit(10).includes(other_notebook: :updater)
       commontator_thread_show(@notebook)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+# Model for feedback
+class Comment < ApplicationRecord 
+    belongs_to :user
+    belongs_to :notebook
+end
+  

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -149,10 +149,10 @@ html lang="en"
                           -if total_open_reviews > 0
                             span.sr-only #{" "}
                             span.hidden aria-hidden="true" #{"("}
-                            span.review-alert ==open_change_requests
+                            span.notice-amount ==open_change_requests
                             span.sr-only #{" alerts"}
                             span.hidden aria-hidden="true" #{")"}
-                            /*span.review-alert ==open_change_requests + total_open_reviews*/
+                            /*span.notice-amount ==open_change_requests + total_open_reviews*/
                           i.fa.fa-user aria-hidden="true"
                           b.caret
                         -else

--- a/app/views/notebooks/_comments.slim
+++ b/app/views/notebooks/_comments.slim
@@ -1,44 +1,67 @@
-div
+div id="commentsContainer"
     -sorted_array = comments.sort {|a,b| a.created_at <=> b.created_at }
     -sorted_array.each do |comment|
-        div.comment-block
-            span.comment-metadata-primary
-                span.comment-block-user
-                    ==link_to_user(User.find(comment.user_id)) if User.find(comment.user_id)
-                ==render partial: "time_ago", locals: {time: comment.created_at}
-            br
-            div.comment-body #{comment.comment}
-            div.comment-metadata-secondary
-                -if comment.ran != nil
-                    -if comment.ran
-                        span.notebook-comment-metadata.tooltips title="User reports they did try running the notebook"
-                            i.fa.fa-check aria-hidden="true"
-                            span.sr-only Ran notebook
-                            span aria-hidden="true" Ran Notebook
-                    -else
-                        span.notebook-comment-metadata.tooltips title="User reports they did not run the notebook"
-                            i.fa.fa-times aria-hidden="true"
-                            span.sr-only Did not run notebook
-                            span aria-hidden="true" Ran Notebook
-                    -if comment.worked != nil
-                        -if comment.worked
-                            span.notebook-comment-metadata.tooltips title="User reports the notebook worked when running it"
+        -if comment.private == false || (comment.private && @user.can_edit?(@notebook, true))
+            div.comment-block
+                span.comment-metadata-primary
+                    span.comment-block-user
+                        ==link_to_user(User.find(comment.user_id)) if User.find(comment.user_id)
+                    ==render partial: "time_ago", locals: {time: comment.created_at}
+                br
+                div.comment-body
+                    -if comment.private
+                        ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Comment is visible to only notebook editors", title: "Comment is visible to only notebook editors", tabindex: "0")
+                    ==comment.comment
+                div.comment-metadata-secondary
+                    -if comment.ran != nil
+                        -if comment.ran
+                            span.notebook-comment-metadata.tooltips title="User reports they did try running the notebook"
                                 i.fa.fa-check aria-hidden="true"
-                                span.sr-only Run was successful
-                                span aria-hidden="true" Run Successful
+                                span.sr-only Ran notebook
+                                span aria-hidden="true" Ran Notebook
                         -else
-                            span.notebook-comment-metadata.tooltips title="User reports the notebook did not work when running it"
+                            span.notebook-comment-metadata.tooltips title="User reports they did not run the notebook"
                                 i.fa.fa-times aria-hidden="true"
-                                span.sr-only Run was unsuccessful
-                                span aria-hidden="true" Run Successful
-            div.comment-actions
-              a href="#" Reply
-              a.modal-activate.tooltips href="#" aria-haspopup="true" title="Edit this comment"
-                i.fa.fa-pencil aria-hidden="true"
-                span.sr-only Edit
-              a.delete-icon.modal-activate.tooltips href="#" aria-haspopup="true" title="Delete this comment"
-                i.fa.fa-trash-o aria-hidden="true"
-                span.sr-only Delete
-    div.comment-block
-        textarea maxlength="1000" placeholder="Enter a comment" aria-label="Enter comment"
-        button.btn.btn-primary Submit
+                                span.sr-only Did not run notebook
+                                span aria-hidden="true" Ran Notebook
+                        -if comment.worked != nil
+                            -if comment.worked
+                                span.notebook-comment-metadata.tooltips title="User reports the notebook worked when running it"
+                                    i.fa.fa-check aria-hidden="true"
+                                    span.sr-only Run was successful
+                                    span aria-hidden="true" Run Successful
+                            -else
+                                span.notebook-comment-metadata.tooltips title="User reports the notebook did not work when running it"
+                                    i.fa.fa-times aria-hidden="true"
+                                    span.sr-only Run was unsuccessful
+                                    span aria-hidden="true" Run Successful
+                div.comment-actions
+                    a.modal-activate.tooltips href="#" aria-haspopup="true" title="Edit this comment"
+                        i.fa.fa-pencil aria-hidden="true"
+                        span.sr-only Edit
+                    a.delete-icon.modal-activate.tooltips href="#" aria-haspopup="true" title="Delete this comment"
+                        i.fa.fa-trash-o aria-hidden="true"
+                        span.sr-only Delete
+    div.comment-block id="newCommentContainer"
+        textarea placeholder="Enter a comment" aria-label="Enter comment" maxlength="1000"
+        span.remaining-characters-warning
+        div class="form-group" id="notebookRun"
+            div class="checkbox"
+            label
+                input name="ran" type="checkbox" value="true"
+                span Ran Notebook
+        div class="form-group" id="notebookWorked" style="display: none"
+            div class="checkbox"
+            label
+                input name="worked" type="checkbox" value="true"
+                span Notebook Worked
+        div class="form-group" id="makeCommentPrivate"
+            div class="checkbox"
+            label
+                input name="worked" type="checkbox" value="true"
+                span
+                    | Make private 
+                    i.fa.fa-question-circle.tooltips title="Notebook owners and editors would be only users able to see" tabindex="0" aria-hidden="true"
+                    span.sr-only Notebook owners and editors would be only users able to see
+        div.button-container
+            button.btn.btn-primary Post

--- a/app/views/notebooks/_comments.slim
+++ b/app/views/notebooks/_comments.slim
@@ -1,0 +1,44 @@
+div
+    -sorted_array = comments.sort {|a,b| a.created_at <=> b.created_at }
+    -sorted_array.each do |comment|
+        div.comment-block
+            span.comment-metadata-primary
+                span.comment-block-user
+                    ==link_to_user(User.find(comment.user_id)) if User.find(comment.user_id)
+                ==render partial: "time_ago", locals: {time: comment.created_at}
+            br
+            div.comment-body #{comment.comment}
+            div.comment-metadata-secondary
+                -if comment.ran != nil
+                    -if comment.ran
+                        span.notebook-comment-metadata.tooltips title="User reports they did try running the notebook"
+                            i.fa.fa-check aria-hidden="true"
+                            span.sr-only Ran notebook
+                            span aria-hidden="true" Ran Notebook
+                    -else
+                        span.notebook-comment-metadata.tooltips title="User reports they did not run the notebook"
+                            i.fa.fa-times aria-hidden="true"
+                            span.sr-only Did not run notebook
+                            span aria-hidden="true" Ran Notebook
+                    -if comment.worked != nil
+                        -if comment.worked
+                            span.notebook-comment-metadata.tooltips title="User reports the notebook worked when running it"
+                                i.fa.fa-check aria-hidden="true"
+                                span.sr-only Run was successful
+                                span aria-hidden="true" Run Successful
+                        -else
+                            span.notebook-comment-metadata.tooltips title="User reports the notebook did not work when running it"
+                                i.fa.fa-times aria-hidden="true"
+                                span.sr-only Run was unsuccessful
+                                span aria-hidden="true" Run Successful
+            div.comment-actions
+              a href="#" Reply
+              a.modal-activate.tooltips href="#" aria-haspopup="true" title="Edit this comment"
+                i.fa.fa-pencil aria-hidden="true"
+                span.sr-only Edit
+              a.delete-icon.modal-activate.tooltips href="#" aria-haspopup="true" title="Delete this comment"
+                i.fa.fa-trash-o aria-hidden="true"
+                span.sr-only Delete
+    div.comment-block
+        textarea maxlength="1000" placeholder="Enter a comment" aria-label="Enter comment"
+        button.btn.btn-primary Submit

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -59,7 +59,7 @@ div.content-container
                 i.fa.fa-download.action-icon aria-hidden="true"
                 span.sr-only Download Notebook
               span.hidden aria-hidden="true" #{" | "}
-          -if @user.can_read?(@notebook)
+          -if false && @user.can_read?(@notebook)
             -if @user.member?
               a.modal-activate.tooltips href="#" id="notebookFeedback" aria-haspopup="true" title="Provide Feedback"
                 i.fa.fa-bullhorn.action-icon aria-hidden="true"
@@ -239,11 +239,18 @@ div.content-container
         button.btn.btn-success id="descriptionEditSubmit" style="float:left" Update
         a id="descriptionEditCancel"
           button.btn.btn-danger Cancel
-    -if defined? @more_like_this and defined? @also_viewed
-      div.center
+    div.center
+      -if defined? @more_like_this and defined? @also_viewed
         a.tooltips href="#" id="recommendationToggle" aria-haspopup="true" aria-expanded="false" title="Toggle recommended notebooks"
           span.show-inline aria-hidden="true" style="display: none" Recommendations
           span.sr-only id="dropdownRecommendationsAriaLabel" Expand Recommendations Dropdown
+          i.fa.fa-chevron-down aria-hidden="true"
+      -if defined? @comments and @user.can_read?(@notebook) and @user.member?
+        a.tooltips href="#" id="commentsToggle" aria-haspopup="true" aria-expanded="false" title="Toggle comments"
+          span.show-inline aria-hidden="true" style="display: none"
+            | Comments
+            span.notice-amount #{@comments.length}
+          span.sr-only id="dropdownRecommendationsAriaLabel" Expand Comments Dropdown
           i.fa.fa-chevron-down aria-hidden="true"
 -if defined? @more_like_this and defined? @also_viewed
   ==render partial: "notebooks/notebook_recommendation_jumbotron"

--- a/app/views/notebooks/show.slim
+++ b/app/views/notebooks/show.slim
@@ -2,5 +2,9 @@
   javascript:
     document.getElementById("main").classList.add("admin_hidden")
 ==render partial: "notebooks/notebook_info_jumbotron"
-div.content-container id="notebookDisplay" role="region" aria-label="Notebook content"
-  ==render partial: "notebook", locals: { notebook: @notebook }
+div.content-container
+  div id="notebookDisplay" role="region" aria-label="Notebook content"
+    ==render partial: "notebook", locals: { notebook: @notebook }
+  div id="commentsDisplay" role="region" aria-label="Comments"
+    ==render partial: "comments", locals: { comments: @comments }
+  

--- a/app/views/notebooks/show.slim
+++ b/app/views/notebooks/show.slim
@@ -5,6 +5,6 @@
 div.content-container
   div id="notebookDisplay" role="region" aria-label="Notebook content"
     ==render partial: "notebook", locals: { notebook: @notebook }
-  div id="commentsDisplay" role="region" aria-label="Comments"
+  div id="commentsDisplay" role="region" aria-label="Comments" style="display: none"
     ==render partial: "comments", locals: { comments: @comments }
   

--- a/app/views/user_preferences/index.slim
+++ b/app/views/user_preferences/index.slim
@@ -60,15 +60,6 @@ div.content-container
         -else
           input id="disable_row_numbers" name="disable_row_numbers" type="checkbox" value="true"
         p Disable code cell line numbers
-    /*div
-      label
-        -if @user_preference.ultimate_accessibility_mode
-          input id="ultimate_accessibility_mode" name="ultimate_accessibility_mode" type="checkbox" value="true" checked="checked"
-        -else
-          input id="ultimate_accessibility_mode" name="ultimate_accessibility_mode" type="checkbox" value="true"
-        p
-          ' Enable Ultimate Accessibility Mode
-          strong #{"[BETA]"}*/
 
     hr.divider.show style="display: none"
     div

--- a/db/migrate/20231114000005_create_comments.rb
+++ b/db/migrate/20231114000005_create_comments.rb
@@ -1,0 +1,23 @@
+class CreateComments < ActiveRecord::Migration[6.1]
+    def self.up
+      create_table :comments do |t|
+
+        t.integer :user_id
+        t.foreign_key :users, on_update: :cascade, on_delete: :nullify
+        t.integer :notebook_id, null: false
+        t.foreign_key :notebooks, on_update: :cascade, on_delete: :cascade
+        t.boolean :private, null: false
+        t.integer :parent_comment_id
+        t.boolean :ran
+        t.boolean :worked
+        t.text :comment, limit: 1000
+
+        t.timestamps null: false
+      end
+    end
+
+    def self.down
+      raise IrreversibleMigration
+    end
+  end
+  

--- a/db/migrate/20311114000035_populate_comments.rb
+++ b/db/migrate/20311114000035_populate_comments.rb
@@ -1,0 +1,43 @@
+class PopulateComments < ActiveRecord::Migration[6.1]
+    def self.up
+
+      # Add all Feedback table rows to new generic Comments table
+      Feedback.all.each do |feedback|
+        comment = ""
+        if feedback.broken_feedback != nil && feedback.broken_feedback.strip.length > 0
+            comment += "Broken Feedback: " + feedback.broken_feedback.strip
+        end
+        if feedback.general_feedback != nil && feedback.general_feedback.strip.length > 0
+            if comment.length > 0 && comment[-1] != "."
+                comment += "."
+            end
+            comment += "General Feedback: " + feedback.general_feedback
+        end
+        if comment.length > 1000
+          comment = comment[0..996] + "..."
+        end
+        Comment.create(user_id: feedback.user_id, notebook_id: feedback.notebook_id, private: true, parent_comment_id: nil, ran: feedback.ran, worked: feedback.worked, comment: comment, created_at: feedback.created_at, updated_at: feedback.updated_at)
+      end
+
+      Commontator::Comment.all.each do |comment|
+        message = ""
+        message = comment.body
+        if message.length > 1000
+          message = message[0..996] + "..."
+        end
+        Comment.create(user_id: comment.creator_id, notebook_id: Commontator::Thread.find(comment.thread_id).commontable_id, private: false, parent_comment_id: nil, ran: nil, worked: nil, comment: message, created_at: comment.created_at, updated_at: comment.updated_at)
+      end
+      #execute "INSERT INTO `comments` (users, notebook, field_3) SELECT (users, field_2, field_3) FROM `feedbacks`;"
+
+      # DO NOT UNCOMMENT until fully satisfied with combined table and functionality
+      #drop_table :commontator_comments
+      #drop_table :commontator_subscriptions
+      #drop_table :commontator_threads
+      #drop_table :feedbacks
+    end
+
+    def self.down
+      raise IrreversibleMigration
+    end
+  end
+  

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_06_164002) do
+ActiveRecord::Schema.define(version: 2031_11_14_000035) do
 
   create_table "change_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "reqid", limit: 255, null: false
@@ -52,6 +52,20 @@ ActiveRecord::Schema.define(version: 2023_10_06_164002) do
     t.datetime "updated_at"
     t.index ["md5"], name: "index_code_cells_on_md5", length: 191
     t.index ["notebook_id"], name: "fk_rails_185a49c378"
+  end
+
+  create_table "comments", charset: "latin1", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "notebook_id", null: false
+    t.boolean "private", null: false
+    t.integer "parent_comment_id"
+    t.boolean "ran"
+    t.boolean "worked"
+    t.text "comment"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["notebook_id"], name: "fk_rails_4f66104237"
+    t.index ["user_id"], name: "fk_rails_03de2dc08c"
   end
 
   create_table "commontator_comments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
@@ -569,6 +583,8 @@ ActiveRecord::Schema.define(version: 2023_10_06_164002) do
   add_foreign_key "clicks", "notebooks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "clicks", "users", on_update: :cascade, on_delete: :cascade
   add_foreign_key "code_cells", "notebooks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "comments", "notebooks", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "comments", "users", on_update: :cascade, on_delete: :nullify
   add_foreign_key "environments", "users", on_update: :cascade, on_delete: :cascade
   add_foreign_key "execution_histories", "notebooks", on_update: :cascade, on_delete: :cascade
   add_foreign_key "execution_histories", "users", on_update: :cascade, on_delete: :cascade


### PR DESCRIPTION
Closes #212 and #872

Mockups/Screenshots can be found on #212 comments. 

Ignore that both feedbacks and old comments tables would be deleted and combined into a new one. We can keep one and migrate existing, I just didn't want to ruin my database while testing this all.

Would still need:
1. Comments notify via email like feedbacks
2. Comments can be edited and deleted
3. Subscription emails work for these new comments
4. Comment counts on notebook listing are appropriately using the appropriate comments values.
5. All old feedback, comments code, and tables removed (or the old we aren't using removed)