### PR TITLE
Carry Forward Queued Reviews Config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -65,6 +65,9 @@ reviews:
     enabled: false
     label: compliance
 
+# Enable queued reviews (if all are still queued) to stay queued for a notebook revision even if notebook gets updated
+queued_carry_forward_enabled: false
+
 user_permissions:
   propose_review: false
 


### PR DESCRIPTION
Closes #578 

Queued reviews carry over to next versions if all reviews are queued AND the config to allow it is set to true. I recommend making it default functionality but adding it as a config just in case people want it. 