### PR TITLE
Reviews/Change Request Table consistency with Review/Change Request "All" pages

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -33,7 +33,7 @@ class ChangeRequestsController < ApplicationController
 
     @change_requests_owned = ChangeRequest.all_change_requests(@user).where(notebook_id: Notebook.editable_by(@user).map(&:id))
     @change_requests_owned = @change_requests_owned.where("status = 'pending' or updated_at >= ?", 7.days.ago) unless params[:archived] == "true"
-    @change_requests_owned = @change_requests_owned.sort(&sorter)
+    @change_requests_owned = @change_requests_owned.order(updated_at: :desc)
 
     @change_requests = @change_requests_requested + @change_requests_owned
     @has_archived = (@user.change_requests.count + @user.change_requests_owned.count) > (@change_requests.count)

--- a/app/views/application/_reviews.slim
+++ b/app/views/application/_reviews.slim
@@ -30,16 +30,21 @@
         th Reviewer
         th Time
     tbody
-      -sorted_array = reviews.sort {|a,b| b.updated_at <=> a.updated_at }
+      -if GalleryConfig.notebook_title_parse.parsing_enabled
+        -sorted_array = reviews.order(:updated_at).sort {|a,b| a.notebook.title.partition(GalleryConfig.notebook_title_parse.after_character)[2].downcase <=> b.notebook.title.partition(GalleryConfig.notebook_title_parse.after_character)[2].downcase }
+      -else
+        -sorted_array = reviews.order(:updated_at).sort {|a,b| a.notebook.title.downcase <=> b.notebook.title.downcase }
       -sorted_array.each do |review|
         -if !review.notebook.public? && !(@user.admin? || @user.can_edit?(review.notebook))
           -next
         -else
           tr
-            td
-              -if !review.notebook.public? && (@user.admin? || @user.can_edit?(review.notebook))
-                ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Private Notebook", title: "This notebook is private", tabindex: "0")
-              ==link_to_notebook(review.notebook)
+            td data-sort="#{render partial: GalleryConfig.slim.table_notebook_title_text_only, locals: { notebook: review.notebook }}"
+                ==render partial: GalleryConfig.slim.table_row_heading_label, locals: { notebook: review.notebook }
+                -if !review.notebook.public? && (@user.admin? || @user.can_edit?(review.notebook))
+                  ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Private Notebook", title: "This notebook is private", tabindex: "0")
+                a.review-page-title href="#{notebook_path(review.notebook)}" title="#{review.notebook.title}"
+                  ==render partial: GalleryConfig.slim.table_notebook_title_text_only, locals: { notebook: review.notebook }
             -if revisions_found
               td
                 -if review.revision_id != nil

--- a/app/views/change_requests/index.slim
+++ b/app/views/change_requests/index.slim
@@ -32,13 +32,18 @@ div.content-container
             th Time
             th Status
         tbody
-          -sorted_array = @change_requests_owned.sort {|a,b| b.updated_at <=> a.updated_at }
+          -if GalleryConfig.notebook_title_parse.parsing_enabled
+            -sorted_array = @change_requests_owned.sort {|a,b| a.notebook.title.partition(GalleryConfig.notebook_title_parse.after_character)[2].downcase <=> b.notebook.title.partition(GalleryConfig.notebook_title_parse.after_character)[2].downcase }
+          -else
+            -sorted_array = @change_requests_owned.sort {|a,b| a.notebook.title.downcase <=> b.notebook.title.downcase }
           -sorted_array.each do |entry|
             tr class="#{change_request_class(entry.status)}"
-              td
-                -unless entry.notebook.public?
+              td data-sort="#{render partial: GalleryConfig.slim.table_notebook_title_text_only, locals: { notebook: entry.notebook }}"
+                ==render partial: GalleryConfig.slim.table_row_heading_label, locals: { notebook: entry.notebook }
+                -if !entry.notebook.public?
                   ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Private Notebook", title: "This notebook is private", tabindex: "0")
-                ==link_to_notebook(entry.notebook)
+                a.review-page-title href="#{notebook_path(entry.notebook)}"
+                  ==render partial: GalleryConfig.slim.table_notebook_title_text_only, locals: { notebook: entry.notebook }
               td
                 -if entry.status == 'pending'
                   ==link_to('Review', entry)


### PR DESCRIPTION
Closes #426 

Made Reviews Index and Change Request Index filtered by title the same way All Reviews and All Change Requests does

Have NOT confirmed yet that it works with custom title parsing/configs but out-of-the-box experience works and I am confident customs should work.