### PR TITLE
Fixed Enter/Spacebar 'click' functionality for Buttons, a Tags and .keyboard-friendly Class

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -7,7 +7,7 @@ $(document).ready(function(){
     var keycode = (e.keyCode ? event.keyCode : event.which);
     if (keycode == '13' || keycode == '32'){
         e.preventDefault();
-        $(this).click();
+        this.click();
     }
   });
   /* Have Modals gain focus whenever opened - in the event of default behavior failing */


### PR DESCRIPTION
**References**

This fixes the enter/spacebar click functionality for https://github.com/nbgallery/nbgallery/issues/982

**Code changes**

I have changed `$(this).click();` to `this.click();` in `gallery.js.erb`

**User-facing changes**

Users who navigate using the keyboard can now click on buttons, a tags (i.e. menu items) and any element with the `.keyboard-friendly` class.

**Backwards-incompatible changes**

None