### PR TITLE
onkeydown handler for languages links

### DIFF
--- a/app/views/languages/index.slim
+++ b/app/views/languages/index.slim
@@ -4,7 +4,7 @@ div.content-container
     -sorted_language_array = @languages.sort {|a,b| b[2] <=> a[2] }
     -sorted_language_array.each do |lang, version, count|
       li.list-group-item
-        a.tooltips href="#{language_link(lang, version)}" title="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}" aria-label="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}"
+        a.tooltips href="#{language_link(lang, version)}" onkeydown="if(event.key === 'Enter' || event.key === ' ') window.location = '#{language_link(lang, version)}'" title="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}" aria-label="See Notebooks with coding language of #{lang.capitalize}#{version ? ' ' + version : ''}"
           ==image_tag(language_thumbnail(lang, version), alt: "", aria: {"hidden": true})
           span "#{lang.capitalize}#{version ? ' ' + version : ''}"
         span.sr-only #{" "}


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

This PR aims to partially solve solve some of the 'Keyboard Navigation' issues outlined in the link above. E.g. Enter/Spacebar functionality, specifically the inability to filter notebooks by language through use of keyboard within the 'All Languages' page. 

**Code changes:**
- keydown event handler added to language filter links to replicate mouse functionality


**User-facing changes:**
- None visible
- languages links can be interacted with using keyboard imitating mouse functionality


**To replicate:**
- Open 'All Languages' page
- `Tab` to first link and press `Enter`, expect to be taken to correct language filtered notebook page
- Repeat for other languages links
- repeat using `Space` to ensure functionality is the same