### PR TITLE
Accessibility Keyboard Navigation - Fix opening Dialogs with enter and space key press

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -6,7 +6,8 @@ $(document).ready(function(){
   $('.keyboard-friendly, a, button').keydown(function(e){
     var keycode = (e.keyCode ? event.keyCode : event.which);
     if (keycode == '13' || keycode == '32'){
-        e.preventDefault();
+        e.preventDefault();        
+        e.stopPropagation()
         this.click();
     }
   });

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -7,7 +7,7 @@ $(document).ready(function(){
     var keycode = (e.keyCode ? event.keyCode : event.which);
     if (keycode == '13' || keycode == '32'){
         e.preventDefault();        
-        e.stopPropagation()
+        e.stopPropagation();
         this.click();
     }
   });


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

This PR aims to partially solve solve some of the 'Keyboard Navigation' issues outlined in the link above. E.g. Enter/Spacebar functionality, specifically the inability to open dialogs with first `Enter`/`Space`key press on a button. Previously pressing `Enter` or `Space` causes a dialog to open and then immediately close again.

**Code changes:**
- `e.stopPropagation() `added to acessibility key down handler within gallery.js.erb


**User-facing changes:**
- Buttons which open a dialog on click will now open on first key press of Enter or Space (e.g. create group/upload buttons)


**To replicate:**
- `Tab` to upload and press `Enter`, expect dialog to open correctly first time
- Repeat for other dialog buttons e.g. 'Create Group' within the _All Groups_ page
- repeat using `Space` key to ensure functionality is the same