### PR TITLE
Fixed text wrap styling at 400% zoom

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2740,16 +2740,20 @@ body.page-metrics {
     div.code-block {
         counter-increment: line;
         padding-left: 5px;
+        margin-left: 3.5em;
     }
     div.code-block:before {
         -webkit-user-select: none;
         border-right: 1px solid $primary-border-color;
         color: $intermediate-icon-color;
         content: counter(line);
+        text-align: center;
         display: inline-block;
+        position: absolute;
+        left: 1em;
         margin-right: .5em;
         min-width: 3em;
-        padding: 0 .5em;
+        padding: 0;
     }
 }
 div.cellBad,

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2739,8 +2739,8 @@ body.page-metrics {
     }
     div.code-block {
         counter-increment: line;
-        padding-left: 5px;
-        margin-left: 3.5em;
+        padding-left: 3.5em;
+        position: relative;
     }
     div.code-block:before {
         -webkit-user-select: none;
@@ -2750,9 +2750,9 @@ body.page-metrics {
         text-align: center;
         display: inline-block;
         position: absolute;
-        left: 1em;
+        left: 0em;
         margin-right: .5em;
-        min-width: 3em;
+        min-width: 2em;
         padding: 0;
     }
 }


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

10. Long lines in code cells wrap into line number margin.

In an accessibility audit (linked above) it was noticed that the test wrap of code cells could be aligned better for users that view the web page at high zoom levels. This PR aims to solve this with CSS styling.


**Code changes:**
- CSS styling of code-blocks were edited to move content right and to reposition line numbers absolutely so that they are centered on the left hand side. 


**User-facing changes:**
- In an open Jupyter Notebook, text no longer wraps beneath line numbers at 400% zoom; instead they are left aligned and offset to the right of line numbers.


**To replicate:**
- Open any Jupyter Notebook, zoom in to 400% and expect text within code block not to wrap beneath line numbers.