### PR TITLE
Accessibility - Added aria-label for homepage search button

### DIFF
--- a/app/views/static_pages/home.slim
+++ b/app/views/static_pages/home.slim
@@ -13,7 +13,7 @@
               a.tooltips href="#" id="searchTooltipButton" title="Toggle advanced search filtering help"
                 i.info-button.fa.fa-info-circle aria-hidden="true"
                 span.sr-only Toggle advanced search filtering information dialog
-              button.btn.search-submit
+              button.btn.search-submit aria-label="search"
                 i.fa.fa-search aria-hidden="true"
                   span.sr-only Search
             div.form-group


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

 14. Magnifying glass button within search on homepage just announces 'button'.

In an accessibility audit (linked above) it was noticed that the search button on the homepage (magnifying glass icon) isn't announced correctly by screen readers. 


**Code changes:**
- Aria label added to the button to enable correct screen reader announcement


**User-facing changes:**
- Screen reader will now announce 'Search button' on focus.


**To replicate:**
- On the homepage, with a screen reader active `Tab`to the search button icon
- Expect screen reader to announce 'Search button' 