### PR TITLE
Keyboard Accessibility - Added Arrow Up/Down Functionality to Dropdown Menus

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -18,6 +18,32 @@ $(document).ready(function(){
     $(href).focus();
   });
 
+  $('.dropdown-menu').keydown(function (e) {
+    var keycode = (e.keyCode ? event.keyCode : event.which);   
+  if (keycode == '9') {
+    closeUserDropdown();
+  }  
+  })
+
+  $('li').keydown(function (e) {
+    var keycode = (e.keyCode ? event.keyCode : event.which);  
+    if (keycode == '40') {
+      e.preventDefault();
+      var nextListItem = e.target.parentElement.nextElementSibling.firstElementChild;
+      if (nextListItem === null) {
+        nextListItem = e.target.parentElement.nextElementSibling.nextElementSibling.firstElementChild;
+        if (nextListItem === null) {
+          nextListItem = e.target.parentElement.nextElementSibling.nextElementSibling.nextElementSibling.firstElementChild;
+        }
+      }
+      $(nextListItem).focus();
+    } else if (keycode == '38') {
+      e.preventDefault();
+      var nextListItem = e.target.parentElement.previousElementSibling.firstElementChild;
+      $(nextListItem).focus();
+    }
+  });
+
   /* ===================================== */
   /* ======= Header Functionality ======== */
   /* ===================================== */

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -4,7 +4,7 @@ $(document).ready(function(){
   /* =========== Accessibility =========== */
   /* ===================================== */
   $('.keyboard-friendly, a, button').keydown(function(e){
-    var keycode = (e.keyCode ? event.keyCode : event.which);
+    var keycode = (e.keyCode ? e.keyCode : e.which);
     if (keycode == '13' || keycode == '32'){
         e.preventDefault();
         this.click();
@@ -18,29 +18,53 @@ $(document).ready(function(){
     $(href).focus();
   });
 
-  $('.dropdown-menu').keydown(function (e) {
-    var keycode = (e.keyCode ? event.keyCode : event.which);   
-  if (keycode == '9') {
-    closeUserDropdown();
-  }  
-  })
+  $(document).click(function (e) {
+    var clickTarget = e.target;
+    if (!clickTarget.classList.contains('dropdown-toggle') && !clickTarget.classList.contains('dropdown-menu') && !clickTarget.classList.contains('dropdown-header')) {
+      closeUserDropdown();
+      closeLearnDropdown();
+      closeNotebooksDropdown();
+      closeSearch();
+      closeNotebooksGearDropdown();
+    }
+  });
 
-  $('li').keydown(function (e) {
-    var keycode = (e.keyCode ? event.keyCode : event.which);  
+  $(document).keydown(function (e) {
+    var keycode = (e.keyCode ? e.keyCode : e.which);   
+    if (keycode == '9') {
+      var clickTarget = e.target;
+      if (!clickTarget.classList.contains('dropdown-toggle') && !clickTarget.classList.contains('dropdown-menu') && !clickTarget.classList.contains('dropdown-header') && !clickTarget.classList.contains('tooltips')) {
+        closeUserDropdown();
+        closeLearnDropdown();
+        closeNotebooksDropdown();
+        closeSearch();
+        closeNotebooksGearDropdown();
+      }
+    }
+  });
+
+    $('li').keydown(function (e) {
+    var keycode = (e.keyCode ? e.keyCode : e.which);  
     if (keycode == '40') {
       e.preventDefault();
       var nextListItem = e.target.parentElement.nextElementSibling.firstElementChild;
       if (nextListItem === null) {
         nextListItem = e.target.parentElement.nextElementSibling.nextElementSibling.firstElementChild;
-        if (nextListItem === null) {
+        if (nextListItem === null || nextListItem.tagName === "SPAN") {
           nextListItem = e.target.parentElement.nextElementSibling.nextElementSibling.nextElementSibling.firstElementChild;
         }
       }
       $(nextListItem).focus();
     } else if (keycode == '38') {
       e.preventDefault();
-      var nextListItem = e.target.parentElement.previousElementSibling.firstElementChild;
-      $(nextListItem).focus();
+      var previousListItem = e.target.parentElement.previousElementSibling.firstElementChild;
+      if (previousListItem === null || previousListItem.tagName === "SPAN") {
+        previousListItem = e.target.parentElement.previousElementSibling.previousElementSibling.firstElementChild;
+        if (previousListItem === null || previousListItem.tagName === "SPAN") {
+          previousListItem = e.target.parentElement.previousElementSibling.previousElementSibling.previousElementSibling.firstElementChild;
+        }
+      }
+      $(previousListItem).focus();
     }
   });
 
@@ -64,6 +88,7 @@ $(document).ready(function(){
     closeNotebooksDropdown();
     closeSearch();
     closeUserDropdown();
+    closeNotebooksGearDropdown();
   });
   $('body.user-anonymous #gearDropdown').on('click', function(){
     $('#loginModal').modal('show');
@@ -85,6 +110,7 @@ $(document).ready(function(){
     closeMoreMenu();
     closeNotebooksDropdown();
     closeSearch();
+    closeNotebooksGearDropdown();
     return false;
   });
   $('#learnMore').click(function(event) {
@@ -104,6 +130,30 @@ $(document).ready(function(){
     closeNotebooksDropdown();
     closeUserDropdown();
     closeSearch();
+    closeNotebooksGearDropdown();
+  });
+
+  $('#learnMore').keydown(function(e) {
+    var keycode = (e.keyCode ? e.keyCode : e.which);
+    if (keycode == '13' || keycode == '32'){
+      e.preventDefault();
+      $(this).toggleClass('open');
+      $('#learnMoreDropdown').toggleClass('expand');
+      if ($(this).hasClass('open')){
+        $('#learnMoreDropdown').css("display","block");
+        $('#learnMoreDropdownAriaLabel').text('Collapse Learn More Menu')
+      }
+      else {
+        $('#learnMoreDropdown').css("display","none");
+        $('#learnMoreDropdownAriaLabel').text('Expand Learn More Menu')
+      }
+      toggleAriaExpanded(this);
+      closeMoreMenu();
+      closeNotebooksDropdown();
+      closeUserDropdown();
+      closeSearch();
+      closeNotebooksGearDropdown();
+    }
   });
   function closeLearnDropdown(){
     $('#learnMore').removeClass('open');
@@ -132,6 +182,10 @@ $(document).ready(function(){
     $('#dropdownCaretButtonAriaLabel').text('Expand Notebooks Menu')
     $('#dropdownMenu').css("display","none");
     $('#dropdownCaretButton').attr("aria-expanded", "false");
+  }
+  function closeNotebooksGearDropdown(){
+    $('#notebookGearActions').css("display","none");
+    $('#notebookGearDropdownAriaLabel').text('Expand More Options Menu')
   }
   function toggleAriaExpanded(element){
     var aria = $(element).attr("aria-expanded");

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -165,22 +165,22 @@ html lang="en"
                               a.beta style="cursor:pointer" tabindex="0"
                                 span.tab Switch Layout*/
                             li
-                              a href="#{summary_user_path(@user)}"
+                              a href="#{summary_user_path(@user)}" tabindex="0"
                                 span.tab Your User Summary
                             li
-                              a href="#{environments_path}"
+                              a href="#{environments_path}" tabindex="-1"
                                 span.tab Jupyter Environments
                             li
-                              a href="#{preferences_path}"
+                              a href="#{preferences_path}" tabindex="-1"
                                 span.tab Jupyter Preferences
                             li
-                              a href="#{user_preferences_path}"
+                              a href="#{user_preferences_path}" tabindex="-1"
                                 span.tab #{GalleryConfig.site.name} Preferences
                             li.divider
                             li.dropdown-header.filter-item My Resources
                             -unless @user.notebooks.count.zero?
                               li
-                                a href="#{user_path(@user)}"
+                                a href="#{user_path(@user)}" tabindex="-1"
                                   span.tab.no-wrap.entry My Notebooks
                                   span.sr-only #{" "}
                                   span.hidden aria-hidden="true" #{"("}
@@ -189,7 +189,7 @@ html lang="en"
                                   span.hidden aria-hidden="true" #{")"}
                             -unless @user.stars.count.zero?
                               li
-                                a href="#{stars_notebooks_path}"
+                                a href="#{stars_notebooks_path}" tabindex="-1"
                                   span.tab.no-wrap.entry Notebooks Starred
                                   span.sr-only #{" "}
                                   span.hidden aria-hidden="true" #{"("}
@@ -198,7 +198,7 @@ html lang="en"
                                   span.hidden aria-hidden="true" #{")"}
                             -unless @user.shares.count.zero?
                               li
-                                a href="#{shared_with_me_notebooks_path}"
+                                a href="#{shared_with_me_notebooks_path}" tabindex="-1"
                                   span.tab.no-wrap.entry Notebooks Shared with Me
                                   span.sr-only #{" "}
                                   span.hidden aria-hidden="true" #{"("}
@@ -206,7 +206,7 @@ html lang="en"
                                   span.sr-only #{" total"}
                                   span.hidden aria-hidden="true" #{")"}
                             li
-                              a href="#{change_requests_path}"
+                              a href="#{change_requests_path}" tabindex="-1"
                                 span.tab Change Requests
                                 -if open_change_requests > 0
                                   span.sr-only #{" "}
@@ -216,7 +216,7 @@ html lang="en"
                                   span.hidden aria-hidden="true" #{")"}
                             -if GalleryConfig.reviews_enabled
                               li
-                                a href="#{reviews_user_path(@user)}"
+                                a href="#{reviews_user_path(@user)}" tabindex="-1"
                                   span.tab My Reviews
                                   /*-if total_open_reviews > 0
                                     span.sr-only #{" "}
@@ -225,10 +225,10 @@ html lang="en"
                                     span.sr-only #{" alerts"}
                                     span.hidden aria-hidden="true" #{")"} */
                             li
-                              a href="#{subscriptions_path}"
+                              a href="#{subscriptions_path}" tabindex="-1"
                                 span.tab My Subscriptions
                             li
-                              a href="#{groups_user_path(@user)}"
+                              a href="#{groups_user_path(@user)}" tabindex="-1"
                                 span.tab My Groups
                                 span.sr-only #{" "}
                                 span.hidden aria-hidden="true" #{"("}
@@ -239,7 +239,7 @@ html lang="en"
                             -if GalleryConfig.reviews_enabled
                               li.dropdown-header.filter-item All Resources
                               li
-                                a href="#{reviews_path}"
+                                a href="#{reviews_path}" tabindex="-1"
                                   span.tab All Reviews
                               li.divider role="separator"
                             -if user_signed_in?
@@ -250,16 +250,16 @@ html lang="en"
                                   strong ==@user.user_name
                               -if GalleryConfig.username_login_allowed == true
                                 li
-                                  a href="#{edit_user_registration_path}"
+                                  a href="#{edit_user_registration_path}" tabindex="-1"
                                     span.tab Change Password
                               li.divider role="separator"
                             -if @user.admin?
                               li
-                                a href="#{admin_path}"
+                                a href="#{admin_path}" tabindex="-1"
                                   span.tab Admin
                             -if user_signed_in?
                               li
-                                == link_to("Logout", destroy_user_session_path, :method => :delete)
+                                == link_to("Logout", destroy_user_session_path, :method => :delete, tabindex: -1)
         hr.hidden
         -if request.path != "#{root_path}" && !(url_check[1] == "notebooks" && params[:q] != nil)
           div id="expandableSearchDropdown" style="display: none"

--- a/app/views/layouts/layout.slim
+++ b/app/views/layouts/layout.slim
@@ -32,7 +32,7 @@ html lang="en"
                       button.navbar-btn.btn.btn-primary.tooltips title="View all notebooks" id="notebookFilterDropDown" href="#{notebooks_path}" onclick="window.location = '#{notebooks_path}'"  Notebooks
                       button.navbar-btn.btn.btn-primary.dropdown-toggle aria-haspopup="true" aria-expanded="false" id="dropdownCaretButton"
                         | &nbsp;
-                        span.caret
+                        span.caret class="dropdown-toggle"
                         span.sr-only id="dropdownCaretButtonAriaLabel" Expand Notebooks Menu
                       ul.dropdown-menu.notebooksmenu id="dropdownMenu"
                   div.header-nav
@@ -124,16 +124,16 @@ html lang="en"
                                 a href="#{url_for(group)}"
                                   span.tab #{group.name}
                           li.createGroup
-                            a.center.dropdownGroup.modal-activate href="#" aria-haspopup="true" data-target="#newGroup" data-toggle="modal" tabindex="-1"
+                            a.center.dropdownGroup.modal-activate href="#" aria-haspopup="true" data-target="#newGroup" data-toggle="modal" class="dropdown-toggle"
                               button.btn.btn-primary.createGroup Create Group
                       a.tooltips href="#" title="Learn More" id="learnMore" aria-haspopup="true" aria-expanded="false"
-                        span.sr-only id="learnMoreDropdownAriaLabel" Expand Learn More Menu
-                        i.fa.fa-question-circle aria-hidden="true"
-                        b.caret
-                      ul.dropdown-menu id="learnMoreDropdown" style="display: none"
-                        li.dropdown-header.filter-item Documentation
+                        span.sr-only tabindex="-1" id="learnMoreDropdownAriaLabel" Expand Learn More Menu
+                        i.fa.fa-question-circle tabindex="-1" aria-hidden="true" class="dropdown-toggle"
+                        b.caret tabindex="-1" class="dropdown-toggle"
+                      ul.dropdown-menu id="learnMoreDropdown" tabindex="-1" style="display: none"
+                        li.dropdown-header.filter-item tabindex="-1" Documentation
                         li
-                          a href="#{notebooks_path}?q=" Advanced Search
+                          a tabindex="0" href="#{notebooks_path}?q=" Advanced Search
                         li id="learnMoreLink"
                           a href="#" rel="external" What is Jupyter?
                       br.hidden


### PR DESCRIPTION
**Issue:**

This PR address tasks 2 and 3 in https://github.com/nbgallery/nbgallery/issues/980. This enhances keyboard navigability by allowing users to move through menu items using up and down arrow keys. Dropdown menus also close on defocus (click or tab away from menu). Dropdown menus can be opened using enter/spacebar. 

**Code changes:**

 - Added keydown handling function for menu items that handles up/down arrow key navigation
 - Changed tab order to enable up/down key navigation
 - Added click away handling function to close drop down menus when user clicks on different part of application

**User-facing changes:**

Dropdown menus now close when a user clicks away from it. Keyboard navigation users can now use up/down arrow keys to navigate through dropdown menus. Enter/space can be used to open/close dropdown menus. 

**To replicate:**

 - Tab to dropdown menu and press enter/space to open
 - Tab to first menu item
 - Use up/down arrows to navigate in menu
 - Press tab to move away from menu
