### PR TITLE
Screen reader alerts and auto close for search tooltip button

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -424,22 +424,32 @@ $(document).ready(function(){
       }
     });
   });
+  $('form.search-form .searchFieldBox').on('keydown', function(){
+    if (reveal_search_info_message){
+      return
+    }
+    else {
+      closeSearchDialog();  
+    }
+  });
   $('body.page-home #searchTooltipButton').on('click', function(e){
     e.preventDefault();
     let carot_direction = 'top';
     let element = 'form.search-form .form-group:first-child'
     if (reveal_search_info_message){
-      $(element).prepend('<div class="search-tooltip popover ' + carot_direction + ' fade in" role="alert"><div class="arrow"></div><h1 class="popover-title center">Adding Search Filter</h1><div class="popover-content"><p>Filter your search results by adding filters such as:</p><ul><li>user:username</li><li>title:mapping</li><li>description:"interactive maps"</li></ul></div></div>');
+      makeScreenreaderAlert('searchTooltipButtonAlert', 'Adding Search Filter, Filter your search results by adding filters such as: user:username, title:mapping, description:interactive maps');
+      $(element).prepend('<div class="search-tooltip popover ' + carot_direction + ' fade in" role="alert" aria-hidden="true"><div class="arrow"></div><h1 class="popover-title center">Adding Search Filter</h1><div class="popover-content"><p>Filter your search results by adding filters such as:</p><ul><li >user:username</li><li>title:mapping</li><li>description:"interactive maps"</li></ul></div></div>');
       $('form.search-form .searchFieldBox').focus();
       reveal_search_info_message = false;
     }
     else {
       closeSearchDialog();
-      $('form.search-form .searchFieldBox').focus();
+      $('form.search-form .searchFieldBox').focus();  
     }
   });
   function closeSearchDialog(){
     $('.search-tooltip').remove();
+    makeScreenreaderAlert('closeSearchTooltipAlert', 'Closed advanced Search Filtering information dialog');
     reveal_search_info_message = true;
   }
 


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

13. Does not announce the three items within Adding Search Filter tooltip

In an accessibility audit (linked above) it was noticed that when toggling the advanced search filtering help button on the homepage the popup is announced incorrectly. It omits the three list items meaning screen reader dependent users are not getting the information that a non-screen reader user will see.


**Code changes:**
- Screen reader alerts added to search tooltip button on click, message dependent on popup being open or closed.
- Aria-hidden added to the popup that was previously partially announced to prevent duplicate announcement.
- Keydown listener added to search box to automatically close search tooltip popup when navigating away to mimic functionality of clicking outside popup for mouse users. 


**User-facing changes:**
- Screen reader will now announce full text within search tooltip popup.


**To replicate:**
- On the homepage, with a screen reader (Windows Narrator) active `Tab`to the searchTooltipButton icon (right hand side of search bar).
- Press `Enter`.
- Expect screen reader to announce the full text within the popup including the three list items.
- Continue to type in the search input field or `Tab`/`Shift` + `Tab` to navigate away from the search field and expect the popup to close.