### PR TITLE
Added hover/focus indication on active Tab

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2329,6 +2329,10 @@ body.page-home #bigSearchBar {
         color: $secondary-color;
         text-transform: uppercase;
     }
+    .active .tabLink:focus,
+    .active .tabLink:hover {
+        border-color: $secondary-color-darker;
+    }
 }
 
 /* ===== Timeline ===== */


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

Focus indication  on the homepage could be improved as it is not clear when tabbing that a user is focused on the active tab without a visual indication.

**Code changes:**
- CSS styling of active tab added to change the boarder colour on focus and hover.


**User-facing changes:**
- When the active tab on the homepage is focused the boarder colour will change.


**To replicate:**
- On the homepage, `Tab` to the active tab ('Recommended').
- Expect the bottom boarder to switch to a darker orange.
- Test the other tab elements by opening and then setting focus by tabbing/mouse hover and expect the same.