### PR TITLE
Edited duplicate Aria IDs

### DIFF
--- a/app/views/modals/_new_group.slim
+++ b/app/views/modals/_new_group.slim
@@ -1,9 +1,9 @@
-div.modal.fade id="newGroup" aria-labelledby="newGroupHeader" aria-describedby="newGroupDescription" role="dialog" style="display: none" tabindex="0"
+div.modal.fade id="newGroup" aria-labelledby="newGroupHeader" aria-describedby="newGroupDialogDescription" role="dialog" style="display: none" tabindex="0"
   div.modal-dialog
     div.modal-content
       div.modal-header
         h1.modal-title id="newGroupHeader" Create a New Group
-        p.sr-only id="newGroupDescription" Dialog for creating a new group
+        p.sr-only id="newGroupDialogDescription" Dialog for creating a new group
         button.close data-dismiss="modal" aria-label="Close Dialog" &times;
       div.modal-body
         form id="groupForm" action="#{groups_path}" enctype="multipart/form-data" data-toggle="validator"


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

Running a lighthouse accessibility report returned duplicate element IDs; the value of an ARIA ID must be unique to prevent other instances from being overlooked by assistive technologies.

**Code changes:**
- renamed ` id="newGroupDescription"` to `id="newGroupDialogDescription"` for new group dialog screen reader only paragraph


**User-facing changes:**
- None
