### PR TITLE
Changed CSS styling of cells to meet WCAG AAA requirements

### DIFF
--- a/app/assets/stylesheets/formatters.scss
+++ b/app/assets/stylesheets/formatters.scss
@@ -5,14 +5,14 @@
     white-space: pre-wrap;
     word-break: break-all;
     .hll { background-color: #ffc }
-    .c { color: #3e7c7c; font-style: italic } /* Comment */
+    .c { color: #2e5c5c; font-style: italic } /* Comment */
     .err { border: 1px solid #f00 } /* Error */
-    .k { color: #008000; font-weight: bold } /* Keyword */
-    .o { color: #666 } /* Operator */
-    .cm { color: #3e7c7c; font-style: italic } /* Comment.Multiline */
+    .k { color: #006300; font-weight: bold } /* Keyword */
+    .o { color: #545454 } /* Operator */
+    .cm { color: #2e5c5c; font-style: italic } /* Comment.Multiline */
     .cp { color: #9d6600 } /* Comment.Preproc */
-    .c1 { color: #3e7c7c; font-style: italic } /* Comment.Single */
-    .cs { color: #3e7c7c; font-style: italic } /* Comment.Special */
+    .c1 { color: #2e5c5c; font-style: italic } /* Comment.Single */
+    .cs { color: #2e5c5c; font-style: italic } /* Comment.Special */
     .gd { color: #a00000 } /* Generic.Deleted */
     .ge { font-style: italic } /* Generic.Emph */
     .gr { color: #f00 } /* Generic.Error */
@@ -23,49 +23,49 @@
     .gs { font-weight: bold } /* Generic.Strong */
     .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
     .gt { color: #04d } /* Generic.Traceback */
-    .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-    .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-    .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-    .kp { color: #008000 } /* Keyword.Pseudo */
-    .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+    .kc { color: #006300; font-weight: bold } /* Keyword.Constant */
+    .kd { color: #006300; font-weight: bold } /* Keyword.Declaration */
+    .kn { color: #006300; font-weight: bold } /* Keyword.Namespace */
+    .kp { color: #006300 } /* Keyword.Pseudo */
+    .kr { color: #006300; font-weight: bold } /* Keyword.Reserved */
     .kt { color: #b00040 } /* Keyword.Type */
-    .m { color: #666 } /* Literal.Number */
-    .s { color: #ba2121 } /* Literal.String */
+    .m { color: #545454 } /* Literal.Number */
+    .s { color: #a51d1d } /* Literal.String */
     .na { color: #7d9029 } /* Name.Attribute */
-    .nb { color: #008000 } /* Name.Builtin */
+    .nb { color: #006300 } /* Name.Builtin */
     .nc { color: #00f; font-weight: bold } /* Name.Class */
     .no { color: #800 } /* Name.Constant */
-    .nd { color: #a2f } /* Name.Decorator */
+    .nd { color: #7f19be } /* Name.Decorator */
     .ni { color: #727272; font-weight: bold } /* Name.Entity */
     .ne { color: #d03932; font-weight: bold } /* Name.Exception */
     .nf { color: #00f } /* Name.Function */
     .nl { color: #767600 } /* Name.Label */
     .nn { color: #00f; font-weight: bold } /* Name.Namespace */
-    .nt { color: #008000; font-weight: bold } /* Name.Tag */
+    .nt { color: #006300; font-weight: bold } /* Name.Tag */
     .nv { color: #19177c } /* Name.Variable */
-    .ow { color: #a2f; font-weight: bold } /* Operator.Word */
+    .ow { color: #7f19be; font-weight: bold } /* Operator.Word */
     .w { color: #727272 } /* Text.Whitespace */
-    .mb { color: #666 } /* Literal.Number.Bin */
-    .mf { color: #666 } /* Literal.Number.Float */
-    .mh { color: #666 } /* Literal.Number.Hex */
-    .mi { color: #666 } /* Literal.Number.Integer */
-    .mo { color: #666 } /* Literal.Number.Oct */
-    .sb { color: #ba2121 } /* Literal.String.Backtick */
-    .sc { color: #ba2121 } /* Literal.String.Char */
-    .sd { color: #ba2121; font-style: italic } /* Literal.String.Doc */
-    .s2 { color: #ba2121 } /* Literal.String.Double */
+    .mb { color: #545454 } /* Literal.Number.Bin */
+    .mf { color: #545454 } /* Literal.Number.Float */
+    .mh { color: #545454 } /* Literal.Number.Hex */
+    .mi { color: #545454 } /* Literal.Number.Integer */
+    .mo { color: #545454 } /* Literal.Number.Oct */
+    .sb { color: #a51d1d } /* Literal.String.Backtick */
+    .sc { color: #a51d1d } /* Literal.String.Char */
+    .sd { color: #a51d1d; font-style: italic } /* Literal.String.Doc */
+    .s2 { color: #a51d1d } /* Literal.String.Double */
     .se { color: #ac5e1f; font-weight: bold } /* Literal.String.Escape */
-    .sh { color: #ba2121 } /* Literal.String.Heredoc */
+    .sh { color: #a51d1d } /* Literal.String.Heredoc */
     .si { color: #b25178; font-weight: bold } /* Literal.String.Interpol */
-    .sx { color: #008000 } /* Literal.String.Other */
+    .sx { color: #006300 } /* Literal.String.Other */
     .sr { color: #b25178 } /* Literal.String.Regex */
-    .s1 { color: #ba2121 } /* Literal.String.Single */
+    .s1 { color: #a51d1d } /* Literal.String.Single */
     .ss { color: #19177c } /* Literal.String.Symbol */
-    .bp { color: #008000 } /* Name.Builtin.Pseudo */
+    .bp { color: #006300 } /* Name.Builtin.Pseudo */
     .vc { color: #19177c } /* Name.Variable.Class */
     .vg { color: #19177c } /* Name.Variable.Global */
     .vi { color: #19177c } /* Name.Variable.Instance */
-    .il { color: #666 } /* Literal.Number.Integer.Long */
+    .il { color: #545454 } /* Literal.Number.Integer.Long */
 }
 
 /* ===== Revisions Diff - Formatter ===== */


### PR DESCRIPTION
**Issue**
[#980](https://github.com/nbgallery/nbgallery/issues/980)

 8. Keywords, comments and logical operators meet WCAG AA for contrast but not AAA
 
In an accessibility audit (linked above) it was noted that colours within notebook cells meet WCAG AA standards but not AAA. This PR aims to address this so that colours meet triple A.

**Code changes:**
- CSS styling cell elements changed to nearest suggested colour that meets AAA contrast ratio using dev tools. 


**User-facing changes:**
- Colours of cell elements have slight changes.
