### PR TITLE
update error message for file uploads when session auth is invalid

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -686,7 +686,7 @@ $(document).ready(function(){
       },
       error: function(response){
         if (response.responseText != null) {
-          makeAlert('error', '#environmentsForm .alert-container', '<strong>Error:</strong> ' + $(response.responseText).find('.error-message').text());
+          makeAlert('error', '#environmentsForm .alert-container', '<strong>Error:</strong> ' + response.responseText);
         }
         else {
           makeAlert('error', '#environmentsForm .alert-container', 'System encountered an error when trying to process the request. ' + response.responseText);

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -685,8 +685,8 @@ $(document).ready(function(){
         location.reload();
       },
       error: function(response){
-        if (response.responseJSON.message != null) {
-          makeAlert('error', '#environmentsForm .alert-container', response.responseJSON.message);
+        if (response.responseText != null) {
+          makeAlert('error', '#environmentsForm .alert-container', '<strong>Error:</strong> ' + $(response.responseText).find('.error-message').text());
         }
         else {
           makeAlert('error', '#environmentsForm .alert-container', 'System encountered an error when trying to process the request. ' + response.responseText);
@@ -1052,7 +1052,7 @@ $(document).ready(function(){
       var location = '';
     }
     else {
-       var location = '#feedbackModal .alert-container';
+       var location = '#uploadFileForm .alert-container';
     }
     makeAlert('error', location , 'Error uploading notebook. ' + response.responseText);
     $('#uploadFileSubmit').attr('disabled', false);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,7 @@ class ApplicationController < ActionController::Base
   rescue_from ChangeRequest::NotPending, with: :bad_change_request
   rescue_from ChangeRequest::BadUpload, with: :bad_change_request
   rescue_from Group::UpdateFailed, with: :group_update_failed
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
 
   #check for beta paramater in url
   def check_beta
@@ -534,6 +535,22 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html {render text: text_error(exception), status: :not_found}
       format.json {render json: json_error(exception), status: :not_found}
+    end
+  end
+
+  def handle_invalid_authenticity_token(exception)
+    respond_to do |format|
+      format.html do
+        render(
+          'errors/invalid_authenticity_token',
+          locals: { exception: exception },
+          layout: false,
+          status: :unprocessable_entity
+        )
+      end
+      format.json do
+        render json: json_error(exception), status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/views/errors/invalid_authenticity_token.slim
+++ b/app/views/errors/invalid_authenticity_token.slim
@@ -1,0 +1,2 @@
+span.error-message
+  |There was a problem processing your request. Please check your input and try again. If the issue persists, refresh the page or log back in.


### PR DESCRIPTION
Resolves issue #579 
- exception handling in the case there is a CSRF token mismatch
- error template for Invalid auth token
- fixed bug on `upload_error` that wouldn't display the error msg 