### PR TITLE
resolved sorting by title when searching for notebooks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,11 +116,11 @@ class ApplicationController < ActionController::Base
   def set_page_and_sort
     @page = params[:page].presence || 1
     @notebooks_per_page = params[:count].presence && params[:count]&.to_i > 0 ? params[:count]&.to_i : GalleryConfig.pagination.notebooks_per_page
-    allowed_sort = %w[updated_at created_at title score views stars runs downloads health trendiness]
+    allowed_sort = %w[updated_at created_at title_sort score views stars runs downloads health trendiness]
     default_sort = params[:q].blank? ? :trendiness : :score
     default_sort = :updated_at if rss_request?
     @sort = (allowed_sort.include?(params[:sort]) ? params[:sort] : default_sort).to_sym
-    @sort_dir = (@sort == :title ? :asc : :desc)
+    @sort_dir = (@sort == :title_sort ? :asc : :desc)
   end
 
   # Set warning page if any

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -52,7 +52,7 @@ class Notebook < ApplicationRecord
     # For sorting...
     time :updated_at
     time :created_at
-    string :title do
+    string :title_sort do
       Notebook.groom(title).downcase
     end
     # Note: tried to join to NotebookSummary for these, but sorting didn't work

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -44,7 +44,7 @@ div.content-container
                   option value="trendiness" id="trendiness" Trending
                   option value="created_at" id="created_at" Recently Created
                   option value="updated_at" id="updated_at" Recently Updated
-                  option value="title" id="title" Title
+                  option value="title_sort" id="title" Title
                   option value="views" id="views" Most Views
                   option value="stars" id="stars" Most Stars
                   option value="runs" id="runs" Most Runs


### PR DESCRIPTION
There was a naming conflict when indexing by :title. Solr was likely using the `text` version of :title which is not compatible for sorting.

resolves #977 