### PR TITLE
removed `hidden` attribute for stages#create endpoint

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -698,7 +698,7 @@ $(document).ready(function(){
             dirtyWordCheck(response,'#editUploadErrorWarning','#editUploadSubmit');
           }
           else {
-            $('#editUploadErrorWarning').html('<strong>Error: </strong>' + response.responseText);
+            $('#editUploadErrorWarning').html('<strong>Error: </strong>' + response.responseText).removeAttr('hidden');
             $('#editUploadSubmit').attr('disabled', false);
           }
         }


### PR DESCRIPTION
Problem: The alert container was set to hidden and when an error occurred, the error message would not display.
```
div.alert-container
          div.alert.alert-danger.text-center hidden="true" id="editUploadErrorWarning"
```
Solution: removed the hidden attribute for the alert container in the event an error occurred.