### PR TITLE
sets the correct sorting `title` for mysql

### DIFF
--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -487,6 +487,8 @@ class Notebook < ApplicationRecord
       order =
         if %i[stars views runs downloads score health trendiness].include?(sort)
           "#{sort} #{sort_dir.upcase}"
+        elsif sort == :title_sort
+          "title"
         else
           "notebooks.#{sort} #{sort_dir.upcase}"
         end


### PR DESCRIPTION
If the user searches for something, the sorting order is done with Solr instead of MySQL. MySQL uses `title` and Solr uses `title_sort` so this needs to be specified.