### PR TITLE
log invalid auth token events

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -539,6 +539,7 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_invalid_authenticity_token(exception)
+    Rails.logger.warn("An exception occurred: #{exception}")
     respond_to do |format|
       format.html do
         render(

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,6 +56,22 @@ Rails.application.configure do
   config.run_solr = true
   config.run_solr = false if ENV['RUN_SOLR'] == 'false'
 
+  # Exception Notification
+  # Uncomment this if you want to receive exception emails.
+  # if GalleryConfig.email.exceptions_to.present?
+  #   config.middleware.use(
+  #     ExceptionNotification::Rack,
+  #     ignore_exceptions: ['ActionController::InvalidAuthenticityToken'],
+  #     email: {
+  #       deliver_with: :deliver,
+  #       email_prefix: "[#{GalleryConfig.site.name} Error]",
+  #       sender_address: GalleryConfig.email.exceptions_from,
+  #       exception_recipients: GalleryConfig.email.exceptions_to,
+  #       sections: %w[controller request exception backtrace session data]
+  #     }
+  #   )
+  # end
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,12 +123,13 @@ Rails.application.configure do
   if GalleryConfig.email.exceptions_to.present?
     config.middleware.use(
       ExceptionNotification::Rack,
+      ignore_exceptions: ['ActionController::InvalidAuthenticityToken'],
       email: {
         deliver_with: :deliver,
         email_prefix: "[#{GalleryConfig.site.name} Error]",
         sender_address: GalleryConfig.email.exceptions_from,
         exception_recipients: GalleryConfig.email.exceptions_to,
-        sections: %w[request backtrace session]
+        sections: %w[controller request exception backtrace session data]
       }
     )
   end


### PR DESCRIPTION
ExceptionNotifier plugin ignores InvalidAuthenticityToken exceptions. Also added more sections to the emails.