### PR TITLE
explicitly set json for dataType

### DIFF
--- a/app/assets/javascripts/notebook_actions.js.erb
+++ b/app/assets/javascripts/notebook_actions.js.erb
@@ -766,6 +766,7 @@ $(document).ready(function(){
         url: url,
         type: ((type=='change') ? 'POST' : 'PUT'),
         data: data,
+        dataType: 'json',
         cache: false,
         contentType: false,
         processData: false,


### PR DESCRIPTION
On some occasions this error would occur:
` Missing template notebooks/update, application/update with {:locale=>[:en], :formats=>[:html], :variants=[], :handlers=>[:raw, :erb, :html, :builder, :ruby,  :jbuilder, :slim]}`

The browser may be defaulting to HTML and attempts to render this non-existent template but the notebooks#update endpoint returns json. Adding `dataType: 'json'` explicitly tells jquery to expect a json response.