### PR TITLE
Notebook Verification Changes

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -393,13 +393,25 @@ $(document).ready(function(){
     $('#filterDeprecatedForm #deprecatedCheckbox').click();
   });
 
+  $('#showVerifiedToken, .tokenfield #onlyVerifiedNotebooksCheckbox').click(function(){
+    $('#filterVerifiedNotebooksForm #onlyVerifiedNotebooksCheckbox').click();
+  });
+
   $('#showPrivateToken, .tokenfield #showPrivateNotebooksCheckbox').click(function(){
     $('#filterPrivateNotebooksForm #showPrivateNotebooksCheckbox').click();
   });
 
   // Filter search results by those that are/aren't deprecated
   $('#filterDeprecatedForm #deprecatedCheckbox').change(function(){
-    $('#filterDeprecatedForm').submit();
+    var params = $('#filterDeprecatedForm').serialize();
+    var url = window.location.href.split("?")[0]
+    window.location = url + "?" + params;
+  });
+
+  $('#filterVerifiedNotebooksForm #onlyVerifiedNotebooksCheckbox').change(function(){
+    var params = $('#filterVerifiedNotebooksForm').serialize();
+    var url = window.location.href.split("?")[0]
+    window.location = url + "?" + params;
   });
 
   // Filter search results by those that are/aren't private notebooks

--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -403,15 +403,11 @@ $(document).ready(function(){
 
   // Filter search results by those that are/aren't deprecated
   $('#filterDeprecatedForm #deprecatedCheckbox').change(function(){
-    var params = $('#filterDeprecatedForm').serialize();
-    var url = window.location.href.split("?")[0]
-    window.location = url + "?" + params;
+    $('#filterDeprecatedForm').submit();
   });
 
   $('#filterVerifiedNotebooksForm #onlyVerifiedNotebooksCheckbox').change(function(){
-    var params = $('#filterVerifiedNotebooksForm').serialize();
-    var url = window.location.href.split("?")[0]
-    window.location = url + "?" + params;
+    $('#filterVerifiedNotebooksForm').submit();
   });
 
   // Filter search results by those that are/aren't private notebooks

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -2642,6 +2642,7 @@ div.search-filters-container {
         line-height: 1.2em;
     }
 }
+#filterVerifiedNotebooksForm input,
 #filterDeprecatedForm input,
 #filterPrivateNotebooksForm input {
     margin: .1em .25em 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -674,7 +674,7 @@ class ApplicationController < ActionController::Base
   #   so you may have to do a .to_a before checking those -- i.e. counting
   #   the results instead of modifying the SQL to do COUNT().
   def query_notebooks
-    Notebook.get(@user, q: params[:q], page: @page, per_page: @notebooks_per_page, sort: @sort, sort_dir: @sort_dir, use_admin: @use_admin, show_deprecated: params[:show_deprecated])
+    Notebook.get(@user, q: params[:q], page: @page, per_page: @notebooks_per_page, sort: @sort, sort_dir: @sort_dir, use_admin: @use_admin, show_deprecated: params[:show_deprecated], show_verified: params[:show_verified])
   end
 
   # Set notebook given various forms of id

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -13,9 +13,8 @@ class GroupsController < ApplicationController
   # GET /groups/:id
   def show
     @notebooks = query_notebooks.where(owner: @group)
-    if(params['show_deprecated'].nil? || params['show_deprecated'] != "true")
-      @notebooks = @notebooks.where("deprecated=False")
-    end
+    @notebooks = @notebooks.where(deprecated: false) unless params[:show_deprecated] && params[:show_deprecated] == "true"
+    @notebooks = @notebooks.where(verified: true) unless !params[:show_verified] || params[:show_verified] != "true"
     respond_to do |format|
       format.html
       format.json {render 'notebooks/index'}

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -870,11 +870,8 @@ class NotebooksController < ApplicationController
       else
         if params[:q].blank?
           if !params.has_key?(:q)
-            if params[:show_verified] && params[:show_verified] == "true"
-              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") ? @notebooks.where(verified: true) : @notebooks.where(deprecated: false, verified: true)
-            else
-              @notebooks = @notebooks.where(deprecated: false) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
-            end
+            @notebooks = @notebooks.where(deprecated: false) unless params[:show_deprecated] && params[:show_deprecated] == "true"
+            @notebooks = @notebooks.where(verified: true) unless !params[:show_verified] || params[:show_verified] != "true"
           end
           @tag_text_with_counts = []
           @groups = []

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -194,7 +194,7 @@ class NotebooksController < ApplicationController
               end
             end
           end
-          @notebook.update_verification
+          @notebook.set_verification(@notebook.review_status == :full)
         end
       end
       render json: { uuid: @notebook.uuid, friendly_url: notebook_path(@notebook) }

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -192,7 +192,9 @@ class NotebooksController < ApplicationController
               review.save!
             end
           end
-          @notebook.toggle_verificaiton
+          if @notebook.verified
+            @notebook.toggle_verification
+          end
         end
       end
       render json: { uuid: @notebook.uuid, friendly_url: notebook_path(@notebook) }

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -192,6 +192,7 @@ class NotebooksController < ApplicationController
               review.save!
             end
           end
+          @notebook.toggle_verificaiton
         end
       end
       render json: { uuid: @notebook.uuid, friendly_url: notebook_path(@notebook) }
@@ -867,7 +868,11 @@ class NotebooksController < ApplicationController
       else
         if params[:q].blank?
           if !params.has_key?(:q)
-            @notebooks = @notebooks.where("notebooks.deprecated=False") unless (params[:show_deprecated] && params[:show_deprecated] == "true")
+            if params[:show_verified] && params[:show_verified] == "true"
+              @notebooks = @notebooks.where(deprecated: false, verified: true) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
+            else
+              @notebooks = @notebooks.where(deprecated: false) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
+            end
           end
           @tag_text_with_counts = []
           @groups = []

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -871,7 +871,7 @@ class NotebooksController < ApplicationController
         if params[:q].blank?
           if !params.has_key?(:q)
             if params[:show_verified] && params[:show_verified] == "true"
-              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") : @notebooks.where(verified: true) ? @notebooks.where(deprecated: false, verified: true)
+              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") ? @notebooks.where(verified: true) : @notebooks.where(deprecated: false, verified: true)
             else
               @notebooks = @notebooks.where(deprecated: false) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
             end

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -871,7 +871,7 @@ class NotebooksController < ApplicationController
         if params[:q].blank?
           if !params.has_key?(:q)
             if params[:show_verified] && params[:show_verified] == "true"
-              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") ? @notebooks.where(deprecated: false, verified: true) : @notebooks.where(verified: true)
+              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") : @notebooks.where(verified: true) ? @notebooks.where(deprecated: false, verified: true)
             else
               @notebooks = @notebooks.where(deprecated: false) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
             end

--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -869,7 +869,7 @@ class NotebooksController < ApplicationController
         if params[:q].blank?
           if !params.has_key?(:q)
             if params[:show_verified] && params[:show_verified] == "true"
-              @notebooks = @notebooks.where(deprecated: false, verified: true) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
+              @notebooks = (params[:show_deprecated] && params[:show_deprecated] == "true") ? @notebooks.where(deprecated: false, verified: true) : @notebooks.where(verified: true)
             else
               @notebooks = @notebooks.where(deprecated: false) unless (params[:show_deprecated] && params[:show_deprecated] == "true")
             end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -97,7 +97,7 @@ class ReviewsController < ApplicationController
       ReviewHistory.create(:review_id => @review.id, :user_id => @user.id, :action => 'approved', :comment =>  @review.comment, :reviewer_id => @review.reviewer_id)
       @review.save
       flash[:success] = "Review has been approved successfully."
-      @review.notebook.update_verification
+      @review.notebook.set_verification(@notebook.review_status == :full)
     else
       flash[:error] = "Review is not currently claimed."
     end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -97,6 +97,9 @@ class ReviewsController < ApplicationController
       ReviewHistory.create(:review_id => @review.id, :user_id => @user.id, :action => 'approved', :comment =>  @review.comment, :reviewer_id => @review.reviewer_id)
       @review.save
       flash[:success] = "Review has been approved successfully."
+      if @review.notebook.review_status == :full
+        @review.notebook.toggle_verificaiton
+      end
     else
       flash[:error] = "Review is not currently claimed."
     end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -98,7 +98,7 @@ class ReviewsController < ApplicationController
       @review.save
       flash[:success] = "Review has been approved successfully."
       if @review.notebook.review_status == :full
-        @review.notebook.toggle_verificaiton
+        @review.notebook.toggle_verification
       end
     else
       flash[:error] = "Review is not currently claimed."

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -97,9 +97,7 @@ class ReviewsController < ApplicationController
       ReviewHistory.create(:review_id => @review.id, :user_id => @user.id, :action => 'approved', :comment =>  @review.comment, :reviewer_id => @review.reviewer_id)
       @review.save
       flash[:success] = "Review has been approved successfully."
-      if @review.notebook.review_status == :full
-        @review.notebook.toggle_verification
-      end
+      @review.notebook.update_verification
     else
       flash[:error] = "Review is not currently claimed."
     end

--- a/app/helpers/notebooks_helper.rb
+++ b/app/helpers/notebooks_helper.rb
@@ -45,23 +45,6 @@ module NotebooksHelper
     end
   end
 
-  def review_status(nb)
-    recent = 0
-    total = 0
-    GalleryConfig.reviews.to_a.each do |revtype, options|
-      next unless options.enabled
-      total += 1
-      recent += 1 if nb.recent_review?(revtype)
-    end
-    if recent.zero?
-      :none
-    elsif recent == total
-      :full
-    else
-      :partial
-    end
-  end
-
   def review_status_string(nb)
     reviewed = GalleryConfig
       .reviews

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -397,7 +397,7 @@ class Notebook < ApplicationRecord
         fulltext(filtered_text, highlight: true) do
           boost_fields title: 50.0, description: 10.0, owner: 15.0, owner_description: 15.0
           boosts.each {|id, info| boost((info[:score] || 0) * 5.0) {with(:id, id)}}
-          boost(2.5) {with(:verified, true)}
+          boost(100.0) {with(:verified, true)}
         end
         search_fields.each do |field,values|
           if(field == "package")

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -918,11 +918,7 @@ class Notebook < ApplicationRecord
     end
   end
 
-  def toggle_verification
-      update!(verified: !verified)
-  end
-
-  def update_verification
-    toggle_verification unless (verified && review_status == :full) || (review_status != :full && !verified)
+  def set_verification(state)
+    update!(verified: state)    
   end
 end

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -106,7 +106,9 @@ class Notebook < ApplicationRecord
       notebook.packages.map { |package| package}
     end
     # verified notebook
-    boolean :verified
+    boolean :verified do
+      verified == true
+    end
     #deprecation status
     boolean :active do
       deprecated == false

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -919,6 +919,6 @@ class Notebook < ApplicationRecord
   end
 
   def set_verification(state)
-    update!(verified: state)    
+    update(verified: state)   
   end
 end

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -921,4 +921,8 @@ class Notebook < ApplicationRecord
   def toggle_verification
       update!(verified: !verified)
   end
+
+  def update_verification
+    toggle_verification unless (verified && review_status == :full) || (review_status != :full && !verified)
+  end
 end

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -915,7 +915,7 @@ class Notebook < ApplicationRecord
     end
   end
 
-  def toggle_verificaiton
+  def toggle_verification
       update!(verified: !verified)
   end
 end

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -329,7 +329,7 @@ class Notebook < ApplicationRecord
       if nb.score < 0
         nb.score = 0
       end
-      [nb.id, { reasons: nb.reasons, score: nb.score || 0, boosts: scores.join('/'), verified: nb.verified }]
+      [nb.id, { reasons: nb.reasons, score: nb.score || 0, boosts: scores.join('/') }]
     end
     boosts.to_h
   end
@@ -396,7 +396,8 @@ class Notebook < ApplicationRecord
       sunspot = Notebook.search do
         fulltext(filtered_text, highlight: true) do
           boost_fields title: 50.0, description: 10.0, owner: 15.0, owner_description: 15.0
-          boosts.each {|id, info| boost(((info[:score] || 0) * 5.0)+(info[:verified] ? 50.0 : 0.0)) {with(:id, id)}}
+          boosts.each {|id, info| boost((info[:score] || 0) * 5.0) {with(:id, id)}}
+          boost(2.5) {with(:verified, true)}
         end
         search_fields.each do |field,values|
           if(field == "package")

--- a/app/views/application/_notebook_listings.slim
+++ b/app/views/application/_notebook_listings.slim
@@ -20,7 +20,7 @@ table.content.nb-table.table-responsive id="#{table_id + 'NotebookListingTable'}
               ==render partial: "language_icons", locals: { notebook: nb }
               span.sr-only #{" "}
               ==render partial: GalleryConfig.slim.table_nb_title, locals: { nb: nb }
-              -status = review_status(nb)
+              -status = nb.review_status
               -if GalleryConfig.reviews_enabled
                 -if status == :full
                   a.nounderline.tooltips href="#{reviews_notebook_path(nb)}"  title="#{review_status_string(nb)}"

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -88,7 +88,7 @@ div.content-container
                     -if value != nil
                       input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
                     -else
-                      input type="hidden" name==CGI.escape_html(key)            
+                      input type="hidden" name==CGI.escape_html(key)
   -if !@notebooks or @notebooks.nil? or @notebooks.empty?
     div.content-container
       div.no-notebooks

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -12,7 +12,7 @@ div.content-container
           th Sort
           -if (request.path.split("/")[1] == "notebooks" && params[:q] == nil) || request.path.split("/")[1] == "tags" || request.path.split("/")[1] == "languages" || request.path.split("/")[1] == "users"|| request.path.split("/")[1] == "groups"
             -if GalleryConfig.reviews_enabled
-              th Show Verified
+              th Show Only Verified
             th Show Deprecated  
             -if @user.admin
               th Show Private

--- a/app/views/application/_notebooks.slim
+++ b/app/views/application/_notebooks.slim
@@ -11,7 +11,9 @@ div.content-container
             th Groups
           th Sort
           -if (request.path.split("/")[1] == "notebooks" && params[:q] == nil) || request.path.split("/")[1] == "tags" || request.path.split("/")[1] == "languages" || request.path.split("/")[1] == "users"|| request.path.split("/")[1] == "groups"
-            th Show Deprecated
+            -if GalleryConfig.reviews_enabled
+              th Show Verified
+            th Show Deprecated  
             -if @user.admin
               th Show Private
       tbody
@@ -57,6 +59,16 @@ div.content-container
                   -else
                     input type="hidden" name==CGI.escape_html(key)
           -if (request.path.split("/")[1] == "notebooks" && params[:q] == nil) || request.path.split("/")[1] == "tags" || request.path.split("/")[1] == "languages" || request.path.split("/")[1] == "users" || request.path.split("/")[1] == "groups"
+            -if GalleryConfig.reviews_enabled
+              td
+                form id="filterVerifiedNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
+                  input id="onlyVerifiedNotebooksCheckbox" aria-label="Show Verified Notebooks Only" checked=(params[:show_verified] == "true"? "checked" : nil)  name="show_verified" type="checkbox" value="true"
+                  -params.each do |key, value|
+                    -next if %w(id show_verified ascending splat captures controller action partial_name ajax).include?(key)
+                    -if value != nil
+                      input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                    -else
+                      input type="hidden" name==CGI.escape_html(key)
             td
               -unless defined? suggested_view
                 form id="filterDeprecatedForm" method="get" action="#{url_for(:only_path => false)}"
@@ -76,7 +88,7 @@ div.content-container
                     -if value != nil
                       input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
                     -else
-                      input type="hidden" name==CGI.escape_html(key)
+                      input type="hidden" name==CGI.escape_html(key)            
   -if !@notebooks or @notebooks.nil? or @notebooks.empty?
     div.content-container
       div.no-notebooks

--- a/app/views/application/_search_banner.slim
+++ b/app/views/application/_search_banner.slim
@@ -117,6 +117,17 @@ div class=(params[:q].blank? || filters.length > 0 ? "super-container" : "super-
                         input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
                       -else
                         input type="hidden" name==CGI.escape_html(key)
+              -if GalleryConfig.reviews_enabled 
+                div.token id="showVerifiedToken"
+                  form id="filterVerifiedNotebooksForm" method="get" action="#{url_for(:only_path => false)}"
+                    label.toggle-label for="onlyVerifiedNotebooksCheckbox" Verified Only
+                    input id="onlyVerifiedNotebooksCheckbox" aria-label="Show Verified Notebooks" checked=(params[:show_verified] == "true"? "checked" : nil) name="show_verified" type="checkbox" value="true"
+                    -params.each do |key, value|
+                      -next if %w(id show_verified ascending splat captures controller action partial_name ajax).include?(key)
+                      -if value != nil
+                        input type="hidden" name==CGI.escape_html(key) value==CGI.escape_html(value)
+                      -else
+                        input type="hidden" name==CGI.escape_html(key)
               -filters.each do |filter|
                 div.token
                   span.token-label ==filter

--- a/app/views/notebooks/_notebook_jumbotron_title.slim
+++ b/app/views/notebooks/_notebook_jumbotron_title.slim
@@ -4,7 +4,7 @@ div id="titleView"
       ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Private Notebook", title: "This notebook is private", tabindex: "0")
     span class="#{@user.can_edit?(@notebook) || @user.admin? ? 'edit' : ''}" id="title"
       ==@notebook.title
-      -status = review_status(@notebook)
+      -status = @notebook.review_status
       -if GalleryConfig.reviews_enabled
         -if status == :full
           a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"

--- a/db/migrate/20250306190247_add_notebook_verified.rb
+++ b/db/migrate/20250306190247_add_notebook_verified.rb
@@ -2,6 +2,6 @@ class AddNotebookVerified < ActiveRecord::Migration[6.1]
   def change
     add_column :notebooks, :verified, :boolean, default: false
     add_index :notebooks, :verified
-    execute("UPDATE notebooks set verified = 0")
+    execute("UPDATE notebooks SET verified = 0")
   end
 end

--- a/db/migrate/20250306190247_add_notebook_verified.rb
+++ b/db/migrate/20250306190247_add_notebook_verified.rb
@@ -1,0 +1,7 @@
+class AddNotebookVerified < ActiveRecord::Migration[6.1]
+  def change
+    add_column :notebooks, :verified, :boolean, default: false
+    add_index :notebooks, :verified
+    execute("UPDATE notebooks set verified = 0")
+  end
+end

--- a/lib/scheduled_jobs.rb
+++ b/lib/scheduled_jobs.rb
@@ -89,11 +89,21 @@ module ScheduledJobs
       log("COMPUTE: compliance reviewers #{Time.current - start}")
     end
 
+    def update_verified_nbs
+      start = Time.current
+      log("COMPUTE: update notebook verification #{Time.current - start}")
+      Notebook.find_each do |nb|
+        nb.set_verification(nb.review_status == :full)
+        nb.save if nb.changed?
+      end
+    end
+
     def nightly_computation
       log('COMPUTE: beginning nightly computation')
       similarity_scores
       recommendations
       reviews
+      update_verified_nbs unless !GalleryConfig.reviews_enabled
       log('COMPUTE: finished nightly computation')
     end
 

--- a/lib/scheduled_jobs.rb
+++ b/lib/scheduled_jobs.rb
@@ -103,7 +103,7 @@ module ScheduledJobs
       similarity_scores
       recommendations
       reviews
-      update_verified_nbs unless !GalleryConfig.reviews_enabled
+      update_verified_nbs
       log('COMPUTE: finished nightly computation')
     end
 

--- a/script/verify_notebooks.rb
+++ b/script/verify_notebooks.rb
@@ -1,4 +1,4 @@
-# To run this script: rails runner script/create_user.rb
+# To run this script: rails runner script/verify_notebooks.rb
 
 puts "Verifying notebooks not properly verified..."
 

--- a/script/verify_notebooks.rb
+++ b/script/verify_notebooks.rb
@@ -3,7 +3,7 @@
 puts "Verifying notebooks not properly verified..."
 
 Notebook.find_each do |nb|
-  nb.set_verification(review_status == :full)
+  nb.set_verification(nb.review_status == :full)
   nb.save if nb.changed?
 end
 

--- a/script/verify_notebooks.rb
+++ b/script/verify_notebooks.rb
@@ -1,0 +1,12 @@
+# To run this script: rails runner script/create_user.rb
+
+puts "Verifying notebooks not properly verified..."
+
+Notebook.find_each do |nb|
+  if nb.review_status == :full
+    nb.toggle_verification
+    nb.save if nb.changed?
+  end
+end
+
+puts "Complete"

--- a/script/verify_notebooks.rb
+++ b/script/verify_notebooks.rb
@@ -3,10 +3,8 @@
 puts "Verifying notebooks not properly verified..."
 
 Notebook.find_each do |nb|
-  if nb.review_status == :full
-    nb.toggle_verification
-    nb.save if nb.changed?
-  end
+  nb.update_verification
+  nb.save if nb.changed?
 end
 
 puts "Complete"

--- a/script/verify_notebooks.rb
+++ b/script/verify_notebooks.rb
@@ -3,7 +3,7 @@
 puts "Verifying notebooks not properly verified..."
 
 Notebook.find_each do |nb|
-  nb.update_verification
+  nb.set_verification(review_status == :full)
   nb.save if nb.changed?
 end
 


### PR DESCRIPTION
## Main Changes:
- notebook entries in database are now explicitly verified or unverified in their table
  - there is also a script that can be run for DBs that already have existing verified notebooks to have them be labeled as such in the table
- users can filter the search and all notebooks to only show verified notebooks
- verified notebooks are directly boosted with an increased score when searching for notebooks.

## Other Comments:
- This is all the big logical stuff I could think of doing with verified notebooks - open to suggestion or additional ideas
- I am thinking that the homepage notebooks need to also be showing verified notebooks in the same way search does, but that can be a separate issue/ticket since this relies much more on manipulating the score based (which I need to think more on) on the recommended notebooks for a specific user.