### PR TITLE
Add custom templates for the exception emails.

### DIFF
--- a/app/views/exception_notifier/_controller.text.erb
+++ b/app/views/exception_notifier/_controller.text.erb
@@ -1,0 +1,32 @@
+<% if @kontroller %>
+  Controller: <%= @kontroller.class.name %>
+  Action: <%= @kontroller.action_name %>
+  
+  <% if @kontroller.respond_to?(:controller_path) %>
+  Controller Path: <%= @kontroller.controller_path %>
+  <% end %>
+  
+  <% if @kontroller.respond_to?(:request) && @kontroller.request.present? %>
+  HTTP Method: <%= @kontroller.request.method %>
+  Format: <%= @kontroller.request.format %>
+  <% end %>
+  
+  <% if @kontroller.respond_to?(:params) && @kontroller.params.present? %>
+  Parameters:
+  <% @kontroller.params.except(:controller, :action).each do |key, value| %>
+    <%= key %>: <%= value.to_s.truncate(100) %>
+  <% end %>
+  <% end %>
+  
+  <% if @kontroller.respond_to?(:session) && @kontroller.session.present? %>
+  Session Keys: <%= @kontroller.session.keys.join(', ') %>
+  <% end %>
+  
+  <% if @kontroller.respond_to?(:headers) && @kontroller.headers.present? %>
+  Important Headers:
+    Content-Type: <%= @kontroller.headers['Content-Type'] %>
+    Accept: <%= @kontroller.headers['Accept'] %>
+  <% end %>
+<% else %>
+  No controller information available (possibly background job)
+<% end %>

--- a/app/views/exception_notifier/_environment.text.erb
+++ b/app/views/exception_notifier/_environment.text.erb
@@ -1,0 +1,26 @@
+Rails Environment: <%= Rails.env %>
+Ruby Version: <%= RUBY_VERSION %>
+Rails Version: <%= Rails::VERSION::STRING %>
+
+<% if @request %>
+Server Name: <%= @request.server_name %>
+Remote IP: <%= @request.remote_ip %>
+User Agent: <%= @request.user_agent %>
+<% end %>
+
+<% if defined?(Process) %>
+Process ID: <%= Process.pid %>
+<% end %>
+
+<% if ENV['HOSTNAME'] %>
+Hostname: <%= ENV['HOSTNAME'] %>
+<% end %>
+
+<% if @env %>
+Environment Variables:
+<% @env.sort.each do |key, value| %>
+  * <%= key %>: <%= value %>
+<% end %>
+<% else %>
+No environment variables available
+<% end %>

--- a/app/views/exception_notifier/_exception.text.erb
+++ b/app/views/exception_notifier/_exception.text.erb
@@ -1,0 +1,4 @@
+<% if @exception %>
+Exception Class: <%= @exception.class.to_s %>
+Exception Message: <%= @exception.message %>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   #       email_prefix: "[#{GalleryConfig.site.name} Error]",
   #       sender_address: GalleryConfig.email.exceptions_from,
   #       exception_recipients: GalleryConfig.email.exceptions_to,
-  #       sections: %w[controller request exception backtrace session data]
+  #       sections: %w[controller request exception backtrace environment session]
   #     }
   #   )
   # end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,7 +129,7 @@ Rails.application.configure do
         email_prefix: "[#{GalleryConfig.site.name} Error]",
         sender_address: GalleryConfig.email.exceptions_from,
         exception_recipients: GalleryConfig.email.exceptions_to,
-        sections: %w[controller request exception backtrace session data]
+        sections: %w[controller request exception backtrace environment session]
       }
     )
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,13 +32,15 @@ services:
   # Uncomment the below container
   # Uncomment the links/depends in nbgallery
   # Set EMAIL_SERVER to 'smtp'
-  # Set EMAIL_PORT to '5025'
-  # visit http://localhost:5080/ to see all emails that were sent by NBGallery during that run
+  # Set EMAIL_PORT to '8025'
+  # visit http://localhost:8080/ to see all emails that were sent by NBGallery during that run
   # Does not preserve data
-  #smtp:
+  # smtp:
   #  image: gessnerfl/fake-smtp-server:latest
   #  ports:
-  #    - "5080:5080"
+  #    - "8080:8080"      # expose web ui
+  #    - "8025:8025"      # expose smtp port
+  #    - "8082:8081"      # expose management api
 
   ########################################
   # Notebook Gallery

--- a/docker-dev.sh
+++ b/docker-dev.sh
@@ -40,6 +40,16 @@ docker run \
   -v `pwd`/docker/log:/usr/src/nbgallery/log \
   -v `pwd`/docker/data:/usr/src/nbgallery/data \
   -v `pwd`/docker/bundle:/usr/src/nbgallery/bundle \
+  -e EMAIL_DEFAULT_URL_OPTIONS=127.0.0.1:3000 \
+  -e EMAIL_ADDRESS=nbgallery_developers@dev.com \
+  -e EMAIL_SERVER=smtp \
+  -e EMAIL_DOMAIN=dev.com \
+  -e EMAIL_PORT=8025 \
+  -e GALLERY__EMAIL__GENERAL_FROM=nbgallery_developers@dev.com \
+  -e GALLERY__EMAIL__EXCEPTIONS_FROM=exceptions@dev.com \
+  -e GALLERY__EMAIL__EXCEPTIONS_TO=nbgallery_developers@dev.com \
+  -e GALLERY__EXCEPTIONS__EMAIL_FROM=exceptions@dev.com \
+  -e GALLERY__EXCEPTIONS__EMAIL_TO=nbgallery_developers@dev.com \
   -e GALLERY__DIRECTORIES__DATA=/usr/src/nbgallery/data \
   -e GALLERY__DIRECTORIES__CACHE=/usr/src/nbgallery/data/cache \
   -e GALLERY__DIRECTORIES__CHANGE_REQUESTS=/usr/src/nbgallery/data/change_requests \


### PR DESCRIPTION
- added templates for the controller, environment, and exception sections
- opened necessary ports for the fake-smtp server
- added necessary env vars. for the fake-smtp server and Exception Notification gem
- removed the `data` section as it seems to duplicate in the emails