### PR TITLE
Prometheus /metrics setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,8 @@ gem 'rouge'
 gem 'bootsnap', '>= 1.1.0', require: false
 #Better logging
 gem 'lograge'
+# Prometheus metrics
+gem 'prometheus-client'
 
 # Development only
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pr_geohash (1.0.0)
+    prometheus-client (4.2.4)
+      base64
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -472,6 +474,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   overcommit
+  prometheus-client
   pry-rails
   puma
   rack-cors

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative 'boot'
 require 'rails/all'
 require 'active_record/connection_adapters/mysql2_adapter'
 require_relative '../lib/gallery_lib'
+require_relative '../lib/prometheus/middleware/collector'
+require_relative '../lib/prometheus/middleware/exporter'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -98,7 +100,9 @@ module JupyterGallery
     end
 
     config.encoding = 'utf-8'
-
+    config.middleware.use Prometheus::Middleware::Collector
+    config.middleware.use Prometheus::Middleware::Exporter
+    
     # Set up extension system
     GalleryConfig.directories.extensions.each do |dir|
       config.eager_load_paths += Dir[File.join(dir, '*')]

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,28 @@
+require 'prometheus/client'
+
+prometheus = Prometheus::Client.registry
+
+HTTP_REQUESTS_TOTAL = prometheus.counter(
+  :http_requests_total,
+  docstring: 'Total number of HTTP requests processed by NBGallery',
+  labels: %i[controller action method code path]
+)
+
+ACTIVE_REQUESTS = prometheus.gauge(
+  :active_requests,
+  docstring: 'Number of currently active requests being processed by NBGallery',
+  labels: %i[]
+)
+
+REQUEST_DURATIONS = prometheus.histogram(
+  :http_request_duration_seconds,
+  docstring: 'The HTTP response duration on NBGallery',
+  labels: %i[controller action method path],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10]
+)
+
+EXCEPTIONS_TOTAL = prometheus.counter(
+  :http_exceptions_total,
+  docstring: 'The total number of exceptions raised by NBGallery',
+  labels: %i[exception]
+)

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -1,0 +1,75 @@
+require 'benchmark'
+require 'prometheus/client'
+
+module Prometheus
+  module Middleware
+    class Collector
+      attr_reader :app, :registry
+
+      def initialize(app, options = {})
+        @app = app
+        @registry = options[:registry] || Client.registry
+        @metrics_prefix = options[:metrics_prefix] || 'http_server'
+      end
+
+      def call(env) # :nodoc:
+        trace(env) { @app.call(env) }
+      end
+
+      protected
+
+      def trace(env)
+        ACTIVE_REQUESTS.increment
+        response = nil
+        duration = Benchmark.realtime { response = yield }
+        record(env, response.first.to_s, duration)
+        ACTIVE_REQUESTS.decrement
+        return response
+      rescue => exception
+        EXCEPTIONS_TOTAL.increment(labels: { exception: exception.class.name })
+        ACTIVE_REQUESTS.decrement
+        raise
+      end
+
+      def record(env, code, duration)
+        path = generate_path(env)
+
+        controller = env['action_dispatch.request.parameters']&.[]('controller') || 'unknown'
+        action = env['action_dispatch.request.parameters']&.[]('action') || 'unknown'
+
+        counter_labels = {
+          controller: controller,
+          action: action,
+          method: env['REQUEST_METHOD'].downcase,
+          code:   code,
+          path:   path,
+        }
+
+        duration_labels = {
+          controller: controller,
+          action: action,
+          method: env['REQUEST_METHOD'].downcase,
+          path:   path,
+        }
+
+        HTTP_REQUESTS_TOTAL.increment(labels: counter_labels)
+        REQUEST_DURATIONS.observe(duration, labels: duration_labels)
+      rescue
+        # TODO: log unexpected exception during request recording
+        nil
+      end
+
+      def generate_path(env)
+        full_path = [env['SCRIPT_NAME'], env['PATH_INFO']].join
+
+        strip_ids_from_path(full_path)
+      end
+
+      def strip_ids_from_path(path)
+        path
+          .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=/|$)}, '/:uuid\\1')
+          .gsub(%r{/\d+(?=/|$)}, '/:id\\1')
+      end
+    end
+  end
+end

--- a/lib/prometheus/middleware/exporter.rb
+++ b/lib/prometheus/middleware/exporter.rb
@@ -1,0 +1,88 @@
+require 'prometheus/client'
+require 'prometheus/client/formats/text'
+
+module Prometheus
+  module Middleware
+    class Exporter
+      attr_reader :app, :registry, :path
+
+      FORMATS = [Prometheus::Client::Formats::Text].freeze
+      FALLBACK = Prometheus::Client::Formats::Text
+
+      def initialize(app, options = {})
+        @app = app
+        @registry = options[:registry] || Prometheus::Client.registry
+        @path = options[:path] || '/metrics'
+        @port = options[:port]
+        @acceptable = build_dictionary(FORMATS, FALLBACK)
+      end
+
+      def call(env)
+        if metrics_port?(env['SERVER_PORT']) && env['PATH_INFO'] == @path
+          format = negotiate(env, @acceptable)
+          format ? respond_with(format) : not_acceptable(FORMATS)
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+
+      def negotiate(env, formats)
+        parse(env.fetch('HTTP_ACCEPT', '*/*')).each do |content_type, _|
+          return formats[content_type] if formats.key?(content_type)
+        end
+
+        nil
+      end
+
+      def parse(header)
+        header.split(/\s*,\s*/).map do |type|
+          attributes = type.split(/\s*;\s*/)
+          quality = extract_quality(attributes)
+
+          [attributes.join('; '), quality]
+        end.sort_by(&:last).reverse
+      end
+
+      def extract_quality(attributes, default = 1.0)
+        quality = default
+
+        attributes.delete_if do |attr|
+          quality = attr.split('q=').last.to_f if attr.start_with?('q=')
+        end
+
+        quality
+      end
+
+      def respond_with(format)
+        [
+          200,
+          { 'Content-Type' => format::CONTENT_TYPE },
+          [format.marshal(@registry)],
+        ]
+      end
+
+      def not_acceptable(formats)
+        types = formats.map { |format| format::MEDIA_TYPE }
+
+        [
+          406,
+          { 'Content-Type' => 'text/plain' },
+          ["Supported media types: #{types.join(', ')}"],
+        ]
+      end
+
+      def build_dictionary(formats, fallback)
+        formats.each_with_object('*/*' => fallback) do |format, memo|
+          memo[format::CONTENT_TYPE] = format
+          memo[format::MEDIA_TYPE] = format
+        end
+      end
+
+      def metrics_port?(request_port)
+        @port.nil? || @port.to_s == request_port
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces Prometheus metrics to the app.
Metrics:
- `http_requests_total`: A counter tracking track the total number of HTTP requests processed by NBGallery.
- `active_requests`: A gauge monitoring the number of currently active requests.
- `http_request_duration_seconds`: A histogram measuring HTTP response durations.
- `http_exceptions_total`: A counter for exceptions raised by NBGallery.

Middleware:
Custom middleware (`Prometheus::Middleware::Collector`) is added to track request metrics. An exporter middleware (`Prometheus::Middleware::Exporter`) is included to expose these metrics at a specified path (`/metrics` by default) 