### PR TITLE
LF normalization on the changelog

### DIFF
--- a/app/controllers/notebooks_controller.rb
+++ b/app/controllers/notebooks_controller.rb
@@ -163,6 +163,7 @@ class NotebooksController < ApplicationController
     if GalleryConfig.storage.track_revisions
       friendly_label = params[:friendly_label]
       summary = params[:summary].strip
+      summary = summary.gsub(/\r\n/, "\n")  # Convert CRLF to LF
       label_check_bad = verify_revision_label(friendly_label, @notebook)
       if friendly_label != "" && label_check_bad
         errors += label_check_bad

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -93,6 +93,7 @@ class RevisionsController < ApplicationController
   def edit_summary
     errors = ""
     revision_summary = params[:summary].strip
+    revision_summary = revision_summary.gsub(/\r\n/, "\n")  # Convert CRLF to LF
     if revision_summary.length > 250
       errors += "Revision summary was too long. Summary can only be a maximum of 250 characters and you submitted one that was #{revision_summary.length} characters. "
     end


### PR DESCRIPTION
This PR normalizes line breaks to ensure consistent behavior in the character counting logic:

Our character counting implementation has a discrepancy between client and server. When users enter line breaks in the form:

- In JavaScript (client-side): Each line break counts as 1 character (`\n`)
- In Ruby (server-side): Each line break counts as 2 characters (`\r\n`)

Currently on `main`, the example below would cause an error even though its exactly 250 characters (the maximum limit for a changelog).
```
Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, 
nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium
```
The backend would complain and return an error stating:

`Error: Changelog was too long. Only accepts 250 characters and you submitted one that was 251 characters.`

Solution: Normalize the string to use LF (`\n`) instead of CRLF (`\r\n`).


**Note**: You may have to increase the varchar size of `revisions.commit_message` to `varchar(255)`. My db instance defaulted to `varchar(191)` for some odd reason.
```
ALTER TABLE emp MODIFY COLUMN name VARCHAR(255);`
```