### PR TITLE
Showing the proper reviews on a specific notebook version/revision

### DIFF
--- a/app/helpers/notebooks_helper.rb
+++ b/app/helpers/notebooks_helper.rb
@@ -45,11 +45,11 @@ module NotebooksHelper
     end
   end
 
-  def review_status_string(nb)
+  def review_status_string(nb,revision=nil)
     reviewed = GalleryConfig
       .reviews
       .to_a
-      .select {|revtype, options| options.enabled && nb.recent_review?(revtype)}
+      .select {|revtype, options| options.enabled && nb.recent_review?(revtype,revision)}
       .map {|_revtype, options| options.label}
     if reviewed.present?
       "This notebook has been reviewed for #{reviewed.to_sentence} quality."

--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -616,8 +616,12 @@ class Notebook < ApplicationRecord
   end
 
   # Does notebook have a recent review of this type?
-  def recent_review?(revtype)
-    reviews.where(revtype: revtype, status: 'approved').last&.recent?
+  def recent_review?(revtype,revision=nil)
+    if revision.present?
+      reviews.where(revision_id: revision, revtype: revtype, status: 'approved').last&.recent?(revision)
+    else
+      reviews.where(revtype: revtype, status: 'approved').last&.recent?
+    end
   end
 
 
@@ -926,13 +930,13 @@ class Notebook < ApplicationRecord
   # none: no reviews are found
   # partial: at least one review with approved status has been found
   # full: all recent reviews have an approved status and notebook is verified
-  def review_status
+  def review_status(revision=nil)
     recent = 0
     total = 0
     GalleryConfig.reviews.to_a.each do |revtype, options|
       next unless options.enabled
       total += 1
-      recent += 1 if recent_review?(revtype)
+      recent += 1 if recent_review?(revtype,revision)
     end
     if recent.zero?
       :none

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -39,12 +39,12 @@ class Review < ApplicationRecord
   end
 
   # Is this review "recent"?
-  def recent?
-    latest_revision_id = notebook.revisions.order(id: :desc).where.not(revtype: "metadata").first.id
+  def recent?(revision=nil)
+    latest_revision_id = notebook.revisions.order(id: :desc).where.not(revtype: "metadata").first.id unless revision.present?
     if latest_revision_id
       # Revision tracking is on, so let's say this review is recent if it's for
       # the current revision and is less than a year old.
-      revision_id == latest_revision_id && updated_at > 1.year.ago
+      (revision_id == latest_revision_id || revision_id == revision) && updated_at > 1.year.ago
     else
       # Revision tracking is off, so let's take a stricter definition of recent.
       updated_at > 6.months.ago

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -165,8 +165,13 @@ div.content-container
               -open_reviews = false
               -0.upto(@notebook.reviews.length - 1) do |review_index|
                 -@review = @notebook.reviews[review_index]
-                -if (@review.revision == nil || @review.revision != nil && @review.revision.commit_id == @notebook.revisions[-1].commit_id) && (@review.status == "claimed" || @review.status == "queued" || @review.status == "unapproved")
+                -url_check = request.path.split("/")
+                -if @review.status == "claimed" || @review.status == "queued" || @review.status == "unapproved"
                   -open_reviews = true
+                  -if url_check[3] == "revisions"
+                    -next unless @review.revision.commit_id == @revision.commit_id
+                  -elsif @review.revision.present?
+                    -next unless @review.revision.commit_id == @notebook.revisions[-1].commit_id
                   -if (GalleryConfig.reviews.technical.enabled && @review.revtype == "technical") || (GalleryConfig.reviews.functional.enabled && @review.revtype == "functional") || (GalleryConfig.reviews.compliance.enabled && @review.revtype == "compliance")
                     span class=(@review.status)
                       a href="#{review_path(@review)}"

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -4,7 +4,7 @@ input type="hidden" id="notebookUUID" value="#{@notebook.uuid}"
 -url_check = request.path.split("/")
 -if url_check[3] != "revisions" && @notebook.deprecated_notebook != nil
   ==render partial: 'notebooks/notebook_deprecated_banner'
--if @notebook.unapproved?
+-if url_check[3] != "revisions" && @notebook.unapproved?
   ==render partial: 'notebooks/notebook_unapproved_alert'
 ==render partial: 'alert_container'
 div.content-container

--- a/app/views/notebooks/_notebook_jumbotron_title.slim
+++ b/app/views/notebooks/_notebook_jumbotron_title.slim
@@ -6,21 +6,20 @@ div id="titleView"
       ==@notebook.title
       -url_check = request.path.split("/")
       -if url_check[3] == "revisions"
-        -status = @notebook.review_status(@revision.id)
-      -else
-        -status = @notebook.review_status
+        -rev_id = @revision.id
+      -status = @notebook.review_status(rev_id)
       -if GalleryConfig.reviews_enabled
         -if status == :full
-          a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"
-            ==image_tag("verified-badge.png", class: "tooltips verified-icon", alt: "Full verified badge. #{review_status_string(@notebook)}")
+          a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook, rev_id)}"
+            ==image_tag("verified-badge.png", class: "tooltips verified-icon", alt: "Full verified badge. #{review_status_string(@notebook, rev_id)}")
         -elsif status == :partial
-          a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"
-            ==image_tag("verified-badge-grayed.png", class: "tooltips verified-icon", alt: "Partial verified badge. #{review_status_string(@notebook)}")
+          a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook, rev_id)}"
+            ==image_tag("verified-badge-grayed.png", class: "tooltips verified-icon", alt: "Partial verified badge. #{review_status_string(@notebook, rev_id)}")
         -else
           -revision = fully_reviewed_prior_revision(@notebook, @user)
           -if revision
-            a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"
-              ==image_tag("verified-badge-grayed.png", class: "verified-icon", alt: "Partial verified badge. #{review_status_string(@notebook)}")
+            a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook, rev_id)}"
+              ==image_tag("verified-badge-grayed.png", class: "verified-icon", alt: "Partial verified badge. #{review_status_string(@notebook, rev_id)}")
     -if url_check[3] == "revisions"
       span.revision-version
         -if @revision.friendly_label != nil

--- a/app/views/notebooks/_notebook_jumbotron_title.slim
+++ b/app/views/notebooks/_notebook_jumbotron_title.slim
@@ -4,7 +4,11 @@ div id="titleView"
       ==image_tag("Lock.png", class: "tagLogoLock tooltips", alt: "Private Notebook", title: "This notebook is private", tabindex: "0")
     span class="#{@user.can_edit?(@notebook) || @user.admin? ? 'edit' : ''}" id="title"
       ==@notebook.title
-      -status = @notebook.review_status
+      -url_check = request.path.split("/")
+      -if url_check[3] == "revisions"
+        -status = @notebook.review_status(@revision.id)
+      -else
+        -status = @notebook.review_status
       -if GalleryConfig.reviews_enabled
         -if status == :full
           a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"
@@ -17,7 +21,6 @@ div id="titleView"
           -if revision
             a.nounderline.tooltips href="#{reviews_notebook_path(@notebook)}" title="#{review_status_string(@notebook)}"
               ==image_tag("verified-badge-grayed.png", class: "verified-icon", alt: "Partial verified badge. #{review_status_string(@notebook)}")
-    -url_check = request.path.split("/")
     -if url_check[3] == "revisions"
       span.revision-version
         -if @revision.friendly_label != nil

--- a/app/views/revisions/show.slim
+++ b/app/views/revisions/show.slim
@@ -11,7 +11,10 @@ div.notebook-revision-page id=(@revision.commit_id != @notebook.revisions[-1].co
           -else
             | (#{@revision.commit_id.first(8)}):
         -if @revision.commit_id != @notebook.revisions[-1].commit_id
-          |  you are viewing an older version of this notebook. You can still #{link_to('download', download_notebook_revision_path(@notebook, @revision))} this version, but all other links and metrics are reflecting the most up to date version. Return to #{link_to('Revisions', notebook_revisions_path(@notebook))} to view other versions.
+          |  you are viewing an older version of this notebook. You can still #{link_to('download', download_notebook_revision_path(@notebook, @revision))} this version, but all other links and metrics are reflecting the most up to date version. 
+          -if GalleryConfig.reviews_enabled
+            |  However, the verification status and review links reflect this version of the notebook. 
+          |  Return to #{link_to('Revisions', notebook_revisions_path(@notebook))} to view other versions.
         -else
           |  you are viewing the most up to date version of this notebook. Return to #{link_to('Revisions', notebook_revisions_path(@notebook))} to view other versions.
   ==render partial: 'notebooks/notebook_info_jumbotron'


### PR DESCRIPTION
### What this PR will do once merged
These changes make it so when a user looks up a specific notebook version/revision, the correct reviews and review status will appear on the page. This DOES NOT change the metrics/non-review related actions and will still show and execute those for the current notebook version (starring, subscribing, health checks, other metrics). We can explore doing that at a later date if wanted but in my opinion it's not worth it.

### NOTE
This PR is unrelated to #1022 but if you have reviewed this you will need to merge `origin/filter-unapproved-notebooks` into your local `fix-revision-view-reviews` to fully test it without error (but DO NOT PUSH/SYNC). To avoid the socket error (that is just a result of not having a fake smtp server linked) comment out `app/controllers/notebooks_controllers.rb:212`.