### PR TITLE
Making active an optional notebook method

### DIFF
--- a/app/models/notebook.rb
+++ b/app/models/notebook.rb
@@ -881,6 +881,11 @@ class Notebook < ApplicationRecord
     Notebook.custom_simplify_email?(self,message)
   end
 
+  # include a static active method for defining in extensions
+  def active?
+    true
+  end
+
   # Counts of packages by language
   # Returns hash[language][package] = count
   def self.package_summary

--- a/app/views/application/_notebook_run.slim
+++ b/app/views/application/_notebook_run.slim
@@ -1,11 +1,9 @@
 -if @user.member?
   div.ribbon-wrapper
     div.github-fork-ribbon
-      -if nb.respond_to?(:active?)
-        -if nb.active?
-          ==render partial: "custom_run_in_jupyter", locals: { nb: nb, ref: defined?(ref) ? ref: nil }
-        -else
-          a.run_jupyter.disabled style="cursor: not-allowed; opacity: 0.6;" Run in Jupyter
-      -else 
+      -if nb.active?
+        ==render partial: "custom_run_in_jupyter", locals: { nb: nb, ref: defined?(ref) ? ref: nil }
         a.run_jupyter href="#{notebook_path(nb.uuid)}" Run in Jupyter
         input type="hidden" value="#{(defined?(ref) && !ref.blank? ? ('?ref=' + ref) : '')}"
+      -else
+        a.run_jupyter.disabled style="cursor: not-allowed; opacity: 0.6;" Run in Jupyter

--- a/app/views/notebooks/_notebook_info_jumbotron.slim
+++ b/app/views/notebooks/_notebook_info_jumbotron.slim
@@ -132,7 +132,7 @@ div.content-container
                   a.modal-activate href="#editNotebookModal" id="editNotebook" aria-haspopup="true" data-toggle="modal"
                     i.gear-dropdown-icon.fa.fa-upload aria-hidden="true"
                     span Upload new version
-                -if GalleryConfig.reviews_enabled && GalleryConfig.user_permissions.propose_review && !@user.admin? && @notebook.deprecated_notebook == nil && (@notebook.public? || GalleryConfig.enable_private_notebook_reviews)
+                -if GalleryConfig.reviews_enabled && GalleryConfig.user_permissions.propose_review && !@user.admin? && @notebook.deprecated_notebook == nil && (@notebook.public? || GalleryConfig.enable_private_notebook_reviews) && @notebook.active?
                   li
                     a.modal-activate href="#proposeReviewModal" id="userProposeReview" aria-haspopup="true" data-toggle="modal"
                       i.gear-dropdown-icon.fa.fa-file-code-o aria-hidden="true"
@@ -152,7 +152,7 @@ div.content-container
                     -elsif !@notebook.unapproved?
                       i.gear-dropdown-icon.fa.fa-pencil-square-o aria-hidden="true"
                       span Edit Deprecation Status
-              -if @user.admin? && GalleryConfig.reviews_enabled && @notebook.deprecated_notebook == nil && (@notebook.public? || GalleryConfig.enable_private_notebook_reviews) #Move reviews_enabled to own if statement if another admin-only action is added
+              -if @user.admin? && GalleryConfig.reviews_enabled && @notebook.deprecated_notebook == nil && (@notebook.public? || GalleryConfig.enable_private_notebook_reviews) && @notebook.active? #Move reviews_enabled to own if statement if another admin-only action is added
                 li.divider
                 li.dropdown-header.filter-item Admin Actions
                 li


### PR DESCRIPTION
Originally the notebook was checking to see if active exists. Not really a great way of doing it, so this PR aims to make active a method that can be overwritten by extensions. This will make it easier to develop in the future by offering more flexibility. Checking for active notebook was also added to reviews and modifications were made to backend on displaying "Run in Jupyter" button.