### PR TITLE
Script to remove solr orphans.

### DIFF
--- a/script/remove_solr_orphans.rb
+++ b/script/remove_solr_orphans.rb
@@ -1,6 +1,6 @@
 # To run this script: bundle exec rails runner script/remove_solr_orphans.rb
 #
-# Ths script removes Solr entries for Notebook records that no longer exist in the database
+# This script removes Solr entries for Notebook records that no longer exist in the database
 
 def find_solr_orphans
     solr_ids = []


### PR DESCRIPTION
This script removes Solr entries for Notebook records that no longer exist in the database.

usage: `bundle exec rails runner script/remove_solr_orphans.rb`