### PR TITLE
keep focus on show verified checkbox after page reload

### DIFF
--- a/app/assets/javascripts/gallery.js.erb
+++ b/app/assets/javascripts/gallery.js.erb
@@ -514,6 +514,8 @@ $(document).ready(function(){
       params.splice(params.indexOf('show_unapproved=true'),1);
     }
     window.location = url + "?" + params.join('&');
+    var clicked = 'verified';
+      localStorage.setItem('checkbox', clicked);
   });
 
   $('#filterUnapprovedForm #unapprovedCheckbox').change(function(){
@@ -536,6 +538,10 @@ $(document).ready(function(){
   });
 
   $(document).ready(function () {
+    if (localStorage.getItem('checkbox') === 'verified') {
+      $('#filterVerifiedNotebooksForm #onlyVerifiedNotebooksCheckbox').focus();
+      localStorage.removeItem('checkbox');
+    }
     if (localStorage.getItem('checkbox') === 'deprecated') {
       $('#filterDeprecatedForm #deprecatedCheckbox').focus();
       localStorage.removeItem('checkbox');


### PR DESCRIPTION
**Issue**
https://github.com/nbgallery/nbgallery/issues/980

Keyboard navigation for non-mouse users is difficult when interacting with some input elements.

Final Touches From PR https://github.com/nbgallery/nbgallery/pull/990 for Show Verified Checkbox

**Code changes:**

- Setting state of input elements within local storage
- Function added to to check and remove state when page is rendered and set focus to previously selected element


**User-facing changes**:
- If user has toggled checkbox/drop-down focus will remain on that element once page loads

**To replicate:**

- Navigate to Advanced Search page
- Tab through to Show Verified Only check box, press Space
- Expect focus to remain on the selected checkbox
- Repeat steps for My Notebooks page and include changing the value in the sort drop-down

