### PR TITLE
Added a checker for Notebook size limit on all uploads

### DIFF
--- a/app/models/jupyter_notebook.rb
+++ b/app/models/jupyter_notebook.rb
@@ -16,6 +16,10 @@ class JupyterNotebook
     rescue JSON::ParserError
       raise JupyterNotebook::BadFormat, 'notebook is not valid JSON'
     end
+
+    byte_size = content.bytesize
+    raise JupyterNotebook::BadFormat, 'notebook is too large, try clearing out all output cells' if byte_size > GalleryConfig.max_notebook_size
+
     @errors = ActiveModel::Errors.new(self)
     @text = nil
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -176,6 +176,9 @@ video:
   overview:
   info:
 
+# Maximum notebook size (in bytes) that can be uploaded - make sure this matches the value in your web server config as well
+max_notebook_size: 1048576
+
 # Notebook entries
 notebooks:
   allow_html_description: false


### PR DESCRIPTION
This will avoid a hanging progress bar loading when someone tried to upload a notebook that is over the limit on the backend. No visual cues for user to know that their file was not accepted.