### PR TITLE
Multiple database configuration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -644,13 +644,15 @@ class ApplicationController < ActionController::Base
     return if user.respond_to?(:block_clicks?) && @user.block_clicks?
     notebook = options[:notebook] || @notebook
     notebook_id = notebook&.id || options[:notebook_id]
-    Click.create(
-      user: user,
-      org: user.org,
-      notebook_id: notebook_id,
-      action: action,
-      tracking: options[:tracking]
-    )
+    ActiveRecord::Base.connected_to(role: :writing) do
+      Click.create(
+        user: user,
+        org: user.org,
+        notebook_id: notebook_id,
+        action: action,
+        tracking: options[:tracking]
+      )
+    end
   end
 
   def notebook_title_character_cleanse
@@ -721,5 +723,11 @@ class ApplicationController < ActionController::Base
       end
     GalleryLib.chart_prep(data, keys: keys)
   end
-
+  # Override commontator's helper to always use the write connection,
+  # since mark_as_read_for does a subscription.touch on every call.
+  def commontator_thread_show(commontable)
+    ActiveRecord::Base.connected_to(role: :writing) do
+      super
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,7 +77,7 @@ class ApplicationController < ActionController::Base
 
   # Set the current user
   def set_user
-    ActiveRecord::Base.connected_to(role:writing) do
+    ActiveRecord::Base.connected_to(role: :writing) do
       if user_signed_in?
         @user = current_user
         @user.errors.add(:email, 'You must specify an e-mail address') unless @user.email
@@ -668,7 +668,7 @@ class ApplicationController < ActionController::Base
       if @notebook.title.include?("\\")
         @notebook.title.gsub!("\\", "＼")
       end
-      ActiveRecord::Base.connected_to(role: writing) do
+      ActiveRecord::Base.connected_to(role: :writing) do
         @notebook.save!
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -77,16 +77,18 @@ class ApplicationController < ActionController::Base
 
   # Set the current user
   def set_user
-    if user_signed_in?
-      @user = current_user
-      @user.errors.add(:email, 'You must specify an e-mail address') unless @user.email
-      @user.errors.add(:user_name, 'You must specify a user name') unless @user.user_name
-      if !@user.valid? or !@user.user_name or !@user.email
-        raise User::MissingRequiredFields unless editing_or_updating_current_user
+    ActiveRecord::Base.connected_to(role:writing) do
+      if user_signed_in?
+        @user = current_user
+        @user.errors.add(:email, 'You must specify an e-mail address') unless @user.email
+        @user.errors.add(:user_name, 'You must specify a user name') unless @user.user_name
+        if !@user.valid? or !@user.user_name or !@user.email
+          raise User::MissingRequiredFields unless editing_or_updating_current_user
+        end
+        GroupService.refresh_user(@user)
+      elsif @user.nil?
+        @user = User.new # blank user object - too much breaks otherwise
       end
-      GroupService.refresh_user(@user)
-    elsif @user.nil?
-      @user = User.new # blank user object - too much breaks otherwise
     end
   end
 
@@ -666,7 +668,9 @@ class ApplicationController < ActionController::Base
       if @notebook.title.include?("\\")
         @notebook.title.gsub!("\\", "＼")
       end
-      @notebook.save!
+      ActiveRecord::Base.connected_to(role: writing) do
+        @notebook.save!
+      end
     end
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  connects_to database: { writing: :primary, reading: :primary_replica }
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,14 +26,25 @@ default: &default
   #sslkey: /path/to/private.key
   #sslcert: /path/to/public.crt
 
-development:
+default_replica: &default_replica
   <<: *default
+  host: <%= GalleryConfig.mysql.replica_host || GalleryConfig.mysql.host || 'localhost' %>
+  replica: true
+
+development:
+  primary:
+    <<: *default
+  primary_replica:
+    <<: *default_replica
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  primary: 
+    <<: *default
+  primary_replica:
+    <<: *default_replica
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -55,4 +66,7 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
+  primary:
+    <<: *default
+  primary_replica:
+    <<: *default_replica

--- a/config/initializers/multi_db.rb
+++ b/config/initializers/multi_db.rb
@@ -1,0 +1,44 @@
+# Multi-db Configuration
+#
+# This file is used for configuration settings related to multiple databases.
+#
+# Enable Database Selector
+#
+# Inserts middleware to perform automatic connection switching.
+# The `database_selector` hash is used to pass options to the DatabaseSelector
+# middleware. The `delay` is used to determine how long to wait after a write
+# to send a subsequent read to the primary.
+#
+# The `database_resolver` class is used by the middleware to determine which
+# database is appropriate to use based on the time delay.
+#
+# The `database_resolver_context` class is used by the middleware to set
+# timestamps for the last write to the primary. The resolver uses the context
+# class timestamps to determine how long to wait before reading from the
+# replica.
+#
+# By default Rails will store a last write timestamp in the session. The
+# DatabaseSelector middleware is designed as such you can define your own
+# strategy for connection switching and pass that into the middleware through
+# these configuration options.
+#
+Rails.application.configure do
+  config.active_record.database_selector = { delay: 2.seconds }
+  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+end
+#
+# Enable Shard Selector
+#
+# Inserts middleware to perform automatic shard swapping. The `shard_selector` hash
+# can be used to pass options to the `ShardSelector` middleware. The `lock` option is
+# used to determine whether shard swapping should be prohibited for the request.
+#
+# The `shard_resolver` option is used by the middleware to determine which shard
+# to switch to. The application must provide a mechanism for finding the shard name
+# in a proc. See guides for an example.
+#
+# Rails.application.configure do
+#   config.active_record.shard_selector = { lock: true }
+#   config.active_record.shard_resolver = ->(request) { Tenant.find_by!(host: request.host).shard }
+# end


### PR DESCRIPTION
This feature implements multi-db support with read replication configuation. These changes enables the app to use separate database connection for read and write operations.

Multi-db Rails documentation: https://guides.rubyonrails.org/active_record_multiple_databases.html

Key changes:

1. Database configuration (`config/database.yml`)
    - support primary and replica databases
    - added `default_replica` configuration with replica host support 
2. Application Record (`app/models/application_record.rb`)
    - added `connects_to` configuration to establish connections to both writing (primary) and reading (replica) database
3. Multi-Db Initializer (`config/initializers/multi_db.rb`)
    - new file configuration Rails database selector middleware
    - sets 2-second delay for replicas reads after writes
    - configures automatic connection switching based on http verbage
4. Application Controller (`app/controllers/application_controller.rb`)
    - Wrapped write operations in `ActiveRecord::Base.connected_to(role: :writing)` blocks:
        - User setup in `set_user` method
        - click tracking in `track_click` method
        - notebook saving in `notebook_title_character_cleanse` method
        - comment thread operations in `commontator_thread_show` method

