### PR TITLE
fix: wrap db transactions to writer role

### DIFF
--- a/app/controllers/user_preferences_controller.rb
+++ b/app/controllers/user_preferences_controller.rb
@@ -2,7 +2,9 @@ class UserPreferencesController < ApplicationController
   before_action :verify_login
 
   def index
-    @user_preference = UserPreference.find_or_create_by(user_id: @user.id)
+    ActiveRecord::Base.connected_to(role: :writing) do
+      @user_preference = UserPreference.find_or_create_by(user_id: @user.id)
+    end
   end
 
   # POST /user_preferences#create

--- a/app/models/notebook_daily.rb
+++ b/app/models/notebook_daily.rb
@@ -32,9 +32,11 @@ class NotebookDaily < ApplicationRecord
         daily_score: Math.log(1.0 + s.count.to_f) / log_max
       )
     end
-    NotebookDaily.transaction do
-      NotebookDaily.where(day: day).delete_all # no callbacks
-      NotebookDaily.import(records, validate: false, batch_size: 250)
+    ActiveRecord::Base.connected_to(role: :writing) do
+      NotebookDaily.transaction do
+        NotebookDaily.where(day: day).delete_all # no callbacks
+        NotebookDaily.import(records, validate: false, batch_size: 250)
+      end
     end
   end
 

--- a/app/models/notebook_similarity.rb
+++ b/app/models/notebook_similarity.rb
@@ -48,9 +48,11 @@ class NotebookSimilarity < ApplicationRecord
           score: 1.0 - i * (0.5 / per_notebook)
         )
       end
-      NotebookSimilarity.transaction do
-        NotebookSimilarity.where(notebook_id: notebook.id).delete_all # no callbacks
-        NotebookSimilarity.import(records, validate: false)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        NotebookSimilarity.transaction do
+          NotebookSimilarity.where(notebook_id: notebook.id).delete_all # no callbacks
+          NotebookSimilarity.import(records, validate: false)
+        end
       end
     end
   end

--- a/app/models/recommended_reviewer.rb
+++ b/app/models/recommended_reviewer.rb
@@ -91,9 +91,11 @@ class RecommendedReviewer < ApplicationRecord
             score: score
           )
         end
-        RecommendedReviewer.transaction do
-          RecommendedReviewer.where(review: review).delete_all # no callbacks
-          RecommendedReviewer.import(records)
+        ActiveRecord::Base.connected_to(role: :writing) do
+          RecommendedReviewer.transaction do
+            RecommendedReviewer.where(review: review).delete_all # no callbacks
+            RecommendedReviewer.import(records)
+          end
         end
       end
       nil
@@ -137,9 +139,11 @@ class RecommendedReviewer < ApplicationRecord
             score: score
           )
         end
-        RecommendedReviewer.transaction do
-          RecommendedReviewer.where(review: review).delete_all # no callbacks
-          RecommendedReviewer.import(records)
+        ActiveRecord::Base.connected_to(role: :writing) do
+          RecommendedReviewer.transaction do
+            RecommendedReviewer.where(review: review).delete_all # no callbacks
+            RecommendedReviewer.import(records)
+          end
         end
       end
       nil

--- a/app/models/suggested_group.rb
+++ b/app/models/suggested_group.rb
@@ -21,9 +21,11 @@ class SuggestedGroup < ApplicationRecord
         .map {|id| SuggestedGroup.new(user_id: user.id, group_id: id)}
 
       # Import into database
-      SuggestedGroup.transaction do
-        SuggestedGroup.where(user_id: user).delete_all # no callbacks
-        SuggestedGroup.import(suggested)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        SuggestedGroup.transaction do
+          SuggestedGroup.where(user_id: user).delete_all # no callbacks
+          SuggestedGroup.import(suggested)
+        end
       end
     end
 

--- a/app/models/suggested_notebook.rb
+++ b/app/models/suggested_notebook.rb
@@ -79,9 +79,11 @@ class SuggestedNotebook < ApplicationRecord
       suggested.each {|s| s.score = [[s.score, 1.0].min, 0.0].max}
 
       # Import into database
-      SuggestedNotebook.transaction do
-        SuggestedNotebook.where(user_id: user).delete_all # no callbacks
-        SuggestedNotebook.import(suggested)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        SuggestedNotebook.transaction do
+          SuggestedNotebook.where(user_id: user).delete_all # no callbacks
+          SuggestedNotebook.import(suggested)
+        end
       end
     end
 

--- a/app/models/suggested_tag.rb
+++ b/app/models/suggested_tag.rb
@@ -20,9 +20,11 @@ class SuggestedTag < ApplicationRecord
         .map {|tag| SuggestedTag.new(user_id: user.id, tag: tag)}
 
       # Import into database
-      SuggestedTag.transaction do
-        SuggestedTag.where(user_id: user).delete_all # no callbacks
-        SuggestedTag.import(suggested)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        SuggestedTag.transaction do
+          SuggestedTag.where(user_id: user).delete_all # no callbacks
+          SuggestedTag.import(suggested)
+        end
       end
     end
 

--- a/app/models/users_also_view.rb
+++ b/app/models/users_also_view.rb
@@ -94,9 +94,11 @@ class UsersAlsoView < ApplicationRecord
           score: 1.0
         )
       end
-      UsersAlsoView.transaction do
-        UsersAlsoView.where(notebook_id: notebook.id).delete_all # no callbacks
-        UsersAlsoView.import(records, validate: false)
+      ActiveRecord::Base.connected_to(role: :writing) do
+        UsersAlsoView.transaction do
+          UsersAlsoView.where(notebook_id: notebook.id).delete_all # no callbacks
+          UsersAlsoView.import(records, validate: false)
+        end
       end
     end
   end


### PR DESCRIPTION
Fix: Wrap any db transactions to the `writer` role. 

Example: 
```ruby
ActiveRecord::Base.connected_to(role: :writing) do
  NotebookSimilarity.transaction do
    NotebookSimilarity.where(notebook_id: notebook.id).delete_all # no callbacks
      NotebookSimilarity.import(records, validate: false)
  end
end
```