### PR TITLE
fix a few more controllers for multi-db config and setup multi-db con…

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,5 +1,8 @@
 # User login callbacks
 class CallbacksController < Devise::OmniauthCallbacksController
+
+  around_action :with_writing_connection
+
   %i[github facebook google_oauth2 gitlab azure_activedirectory_v2].each do |provider|
     define_method provider do
       auth = request.env['omniauth.auth']
@@ -46,5 +49,11 @@ class CallbacksController < Devise::OmniauthCallbacksController
       redirect_to edit_user_path(@user)
       #finish_signup_path(@user)
     end
+  end
+
+  private
+
+  def with_writing_connection(&block)
+    ActiveRecord::Base.connected_to(role: :writing, &block)
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  connects_to database: { writing: :primary, reading: :primary_replica }
+  if GalleryConfig.mysql.multi_db_enabled
+    connects_to database: { writing: :primary, reading: :primary_replica }
+  end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,6 +1,8 @@
 Doorkeeper.configure do
   resource_owner_authenticator do
-    current_user || warden.authenticate!(scope: :user)
+    ActiveRecord::Base.connected_to(role: :writing) do
+      current_user || warden.authenticate!(scope: :user)
+    end
   end
   admin_authenticator do |_routes|
     raise User::Forbidden, 'You are not allowed to view this page.' unless current_user && current_user.admin?

--- a/config/initializers/multi_db.rb
+++ b/config/initializers/multi_db.rb
@@ -22,10 +22,18 @@
 # strategy for connection switching and pass that into the middleware through
 # these configuration options.
 #
-Rails.application.configure do
-  config.active_record.database_selector = { delay: 2.seconds }
-  config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+if GalleryConfig.mysql.multi_db_enabled
+  if GalleryConfig.mysql.replica_host.blank?
+    Rails.logger.warn(
+      '[multi_db] multi_db_enabled=true but mysql.replica_host is unset;' \
+      'replica pool points at primary. Write-prevention is active (dry-run).'
+    )
+  end
+  Rails.application.configure do
+    config.active_record.database_selector = { delay: 2.seconds }
+    config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
+    config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  end
 end
 #
 # Enable Shard Selector

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,8 @@ mysql:
   password:
   host:
   port:
+  replica_host:
+  multi_db_enabled: false
 
 # Solr full-text server configuration
 solr:


### PR DESCRIPTION
Fix a few more controllers that were missing the `ActiveRecord::Base.connected_to(role: :writing, &block)` (mainly oauth stuff) and setup a new flag `GalleryConfig.mysql.multi_db_enabled` if you want to enable multi-db configuration (defaults to `false`).

The multi-db properties can be enabled by setting `GALLERY__MYSQL__REPLICA_HOST=<hostname>` and `GALLERY__MYSQL__MULTI_DB_ENABLED=true` in the `.env` file